### PR TITLE
Create admin notifications on new home tutoring requests

### DIFF
--- a/app/api/home-tutoring/submit/route.ts
+++ b/app/api/home-tutoring/submit/route.ts
@@ -16,6 +16,7 @@ import { getCORSHeaders, isOriginAllowed } from '@/lib/cors-config'
 import { storeRegistrationData } from '@/lib/registration-storage'
 import { validateCountryCode, validateEmailDetailed, validatePhoneDetailed } from '@/lib/security'
 import { checkServerSideRateLimit } from '@/lib/server-rate-limiting'
+import { notifyAdminsOfNewRequest } from '@/lib/services/admin-notification-service'
 import { validateCSRFRequest } from '@/lib/services/csrf-service'
 import { sanitizeFormData } from '@/lib/services/input-sanitization-service'
 import { applySecurityHeaders } from '@/lib/services/security-headers-service'
@@ -197,6 +198,18 @@ role: 'parent',
     if (!storeResult.success) {
       devError('Parent storage error details:', storeResult.error)
       return NextResponse.json({ error: ERROR_MESSAGES.STORAGE_ERROR_CODE, details: storeResult.error }, { status: 500 })
+    }
+
+    if (storeResult.data?.id) {
+      notifyAdminsOfNewRequest(storeResult.data.id, {
+        parentName: registrationData.parentName || formData.parentName,
+        parentEmail: formData.parentEmail,
+        studentName: registrationData.studentName || formData.studentName,
+        gradeLevel: registrationData.gradeLevel || formData.gradeLevel,
+        subjects: registrationData.subjects || formData.subjects,
+      }).catch((error) => {
+        devError('Failed to create admin notifications:', error)
+      })
     }
 
     const response = NextResponse.json({ ok: true }, {

--- a/lib/services/admin-notification-service.ts
+++ b/lib/services/admin-notification-service.ts
@@ -1,0 +1,115 @@
+import { supabaseAdmin } from '@/lib/supabase'
+import { devError, devLog } from '@/lib/utils/logger'
+
+export type AdminNotificationType =
+  | 'new_request'
+  | 'tutor_assigned'
+  | 'request_updated'
+  | 'request_cancelled'
+  | 'system'
+  | 'whatsapp_request'
+
+export type AdminNotificationPriority = 'low' | 'medium' | 'high' | 'critical'
+
+export type RelatedEntityType =
+  | 'home_tutoring_request'
+  | 'pending_registration'
+  | 'tutor'
+  | 'parent'
+  | 'system'
+
+interface CreateNotificationParams {
+  notificationType: AdminNotificationType
+  title: string
+  message: string
+  relatedEntityType: RelatedEntityType
+  relatedEntityId: string
+  priority?: AdminNotificationPriority
+}
+
+async function getAllAdminUsers(): Promise<{ id: string; email: string }[]> {
+  const adminClient = supabaseAdmin
+  if (!adminClient) {
+    devError('Supabase admin client not available')
+    return []
+  }
+
+  const { data: admins, error } = await adminClient
+    .from('profiles')
+    .select('id, email')
+    .eq('role', 'super_admin')
+
+  if (error) {
+    devError('Error fetching admin users:', error)
+    return []
+  }
+
+  return admins || []
+}
+
+export async function createAdminNotifications(
+  params: CreateNotificationParams
+): Promise<void> {
+  const adminClient = supabaseAdmin
+  if (!adminClient) {
+    devError('Supabase admin client not available - cannot create notifications')
+    return
+  }
+
+  try {
+    const adminUsers = await getAllAdminUsers()
+
+    if (adminUsers.length === 0) {
+      devLog('No super_admin users found - skipping notification creation')
+      return
+    }
+
+    devLog(`Creating notifications for ${adminUsers.length} admin(s)`)
+
+    const notificationPromises = adminUsers.map((admin) =>
+      adminClient
+        .from('admin_notifications')
+        .insert({
+          admin_id: admin.id,
+          title: params.title,
+          message: params.message,
+          notification_type: params.notificationType,
+          related_entity_type: params.relatedEntityType,
+          related_entity_id: params.relatedEntityId,
+          priority: params.priority || 'medium',
+          is_read: false,
+        })
+    )
+
+    const results = await Promise.allSettled(notificationPromises)
+    const failures = results.filter((result) => result.status === 'rejected')
+    if (failures.length > 0) {
+      devError(`Failed to create ${failures.length} notification(s)`, failures)
+    }
+
+    const successes = results.filter((result) => result.status === 'fulfilled')
+    devLog(`Successfully created ${successes.length} notification(s)`)
+  } catch (error) {
+    devError('Error creating admin notifications:', error)
+  }
+}
+
+export async function notifyAdminsOfNewRequest(
+  pendingRegistrationId: string,
+  registrationData: {
+    parentName: string
+    parentEmail: string
+    studentName: string
+    gradeLevel: string
+    subjects: string
+  }
+): Promise<void> {
+  await createAdminNotifications({
+    notificationType: 'new_request',
+    title: 'New Home Tutoring Request',
+    message: `${registrationData.parentName} requested tutoring for ${registrationData.studentName} (${registrationData.gradeLevel})`,
+    relatedEntityType: 'pending_registration',
+    relatedEntityId: pendingRegistrationId,
+    priority: 'high',
+  })
+}


### PR DESCRIPTION
Summary:
add an admin notification service to fan out alerts to all super_admin users
trigger notifications after successful storeRegistrationData in the home‑tutoring submit route
ensure notification failures don’t block parent submissions