### PR TITLE
feat: add admin notifications API endpoint

### DIFF
--- a/__tests__/app/api/admin/notifications/route.test.ts
+++ b/__tests__/app/api/admin/notifications/route.test.ts
@@ -1,0 +1,314 @@
+import { GET } from '@/app/api/admin/notifications/route'
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/session-management')
+jest.mock('@/lib/services/security-headers-service')
+jest.mock('@/lib/utils/logger', () => ({
+  devError: jest.fn(),
+}))
+
+import { applySecurityHeaders } from '@/lib/services/security-headers-service'
+import { getSessionFromRequest } from '@/lib/session-management'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const adminClient = supabaseAdmin as NonNullable<typeof supabaseAdmin>
+const mockFrom = adminClient.from as jest.MockedFunction<any>
+const mockGetSession = getSessionFromRequest as jest.MockedFunction<typeof getSessionFromRequest>
+const mockApplySecurityHeaders = applySecurityHeaders as jest.MockedFunction<typeof applySecurityHeaders>
+
+describe('GET /api/admin/notifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApplySecurityHeaders.mockImplementation((response) => response as any)
+  })
+
+  it('returns 503 when admin client is unavailable', async () => {
+    jest.resetModules()
+    jest.doMock('@/lib/supabase', () => ({ supabaseAdmin: null }))
+    jest.doMock('@/lib/session-management', () => ({
+      getSessionFromRequest: jest.fn(),
+    }))
+    jest.doMock('@/lib/services/security-headers-service', () => ({
+      applySecurityHeaders: jest.fn((response) => response),
+    }))
+    jest.doMock('@/lib/utils/logger', () => ({ devError: jest.fn() }))
+
+    const { GET: isolatedGet } = await import('@/app/api/admin/notifications/route')
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications')
+    const res = await isolatedGet(req)
+
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Service temporarily unavailable' })
+  })
+
+  it('returns 401 when no session is present', async () => {
+    mockGetSession.mockReturnValue(null)
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications')
+    const res = await GET(req)
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Unauthorized - Please login first' })
+  })
+
+  it('returns 403 when session is not super_admin', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'user-1',
+      email: 'user@example.com',
+      role: 'parent',
+      fullName: 'User',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications')
+    const res = await GET(req)
+
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Forbidden - Admin access required' })
+  })
+
+  it('returns notifications with unread and total counts', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const notifications = [
+      {
+        id: 'notif-1',
+        admin_id: 'admin-1',
+        title: 'New Home Tutoring Request',
+        message: 'Test',
+        notification_type: 'new_request',
+        related_entity_type: 'pending_registration',
+        related_entity_id: 'pending-1',
+        priority: 'high',
+        is_read: false,
+        read_at: null,
+        created_at: new Date().toISOString(),
+      },
+    ]
+
+    const mainQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: notifications, error: null, count: 12 }),
+    }
+
+    const countQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      count: 3,
+      error: null,
+    }
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn((_: string, options?: { head?: boolean }) => {
+        if (options?.head) {
+          return countQuery
+        }
+        return mainQuery
+      }),
+    }))
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications?unread_only=true&limit=5&offset=10')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      notifications,
+      unread_count: 3,
+      total_count: 12,
+      limit: 5,
+      offset: 10,
+    })
+
+    expect(mainQuery.eq).toHaveBeenCalledWith('admin_id', 'admin-1')
+    expect(mainQuery.eq).toHaveBeenCalledWith('is_read', false)
+    expect(mainQuery.order).toHaveBeenCalledWith('is_read', { ascending: true })
+    expect(mainQuery.order).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(mainQuery.range).toHaveBeenCalledWith(10, 14)
+  })
+
+  it('returns 500 when fetching notifications fails', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const mainQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: null, error: { message: 'fail' }, count: null }),
+    }
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn(() => mainQuery),
+    }))
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications')
+    const res = await GET(req)
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Failed to fetch notifications' })
+  })
+
+  it('returns success even when unread count fails', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const mainQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+    }
+
+    const countQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      count: null,
+      error: { message: 'count fail' },
+    }
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn((_: string, options?: { head?: boolean }) => {
+        if (options?.head) {
+          return countQuery
+        }
+        return mainQuery
+      }),
+    }))
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      notifications: [],
+      unread_count: 0,
+      total_count: 0,
+      limit: 50,
+      offset: 0,
+    })
+  })
+
+  it('uses default limit/offset when params are invalid', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const mainQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+    }
+
+    const countQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      count: 0,
+      error: null,
+    }
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn((_: string, options?: { head?: boolean }) => {
+        if (options?.head) {
+          return countQuery
+        }
+        return mainQuery
+      }),
+    }))
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications?limit=0&offset=-5')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.limit).toBe(50)
+    expect(body.offset).toBe(0)
+    expect(mainQuery.range).toHaveBeenCalledWith(0, 49)
+  })
+
+  it('does not filter by read status when unread_only is false', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const mainQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: [], error: null, count: 0 }),
+    }
+
+    const countQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      count: 0,
+      error: null,
+    }
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn((_: string, options?: { head?: boolean }) => {
+        if (options?.head) {
+          return countQuery
+        }
+        return mainQuery
+      }),
+    }))
+
+    const req = new NextRequest('http://localhost:3000/api/admin/notifications?unread_only=false')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mainQuery.eq).toHaveBeenCalledWith('admin_id', 'admin-1')
+    expect(mainQuery.eq).not.toHaveBeenCalledWith('is_read', false)
+  })
+})

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -1,0 +1,110 @@
+import { applySecurityHeaders } from '@/lib/services/security-headers-service'
+import { getSessionFromRequest } from '@/lib/session-management'
+import { supabaseAdmin } from '@/lib/supabase'
+import { devError } from '@/lib/utils/logger'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+function parseLimit(value: string | null): number {
+  const parsed = Number.parseInt(value || '50', 10)
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return 50
+  }
+  return Math.min(parsed, 100)
+}
+
+function parseOffset(value: string | null): number {
+  const parsed = Number.parseInt(value || '0', 10)
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return 0
+  }
+  return parsed
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const adminClient = supabaseAdmin
+    if (!adminClient) {
+      devError('Supabase admin client not available')
+      const errorResponse = NextResponse.json(
+        { error: 'Service temporarily unavailable' },
+        { status: 503 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    const session = getSessionFromRequest(request)
+    if (!session) {
+      const unauthorizedResponse = NextResponse.json(
+        { error: 'Unauthorized - Please login first' },
+        { status: 401 }
+      )
+      return applySecurityHeaders(unauthorizedResponse)
+    }
+
+    if (session.role !== 'super_admin') {
+      const forbiddenResponse = NextResponse.json(
+        { error: 'Forbidden - Admin access required' },
+        { status: 403 }
+      )
+      return applySecurityHeaders(forbiddenResponse)
+    }
+
+    const searchParams = request.nextUrl.searchParams
+    const unreadOnly = searchParams.get('unread_only') === 'true'
+    const limit = parseLimit(searchParams.get('limit'))
+    const offset = parseOffset(searchParams.get('offset'))
+
+    let query = adminClient
+      .from('admin_notifications')
+      .select('*', { count: 'exact' })
+      .eq('admin_id', session.userId)
+
+    if (unreadOnly) {
+      query = query.eq('is_read', false)
+    }
+
+    query = query
+      .order('is_read', { ascending: true })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1)
+
+    const { data: notifications, error, count } = await query
+    if (error) {
+      devError('Error fetching notifications:', error)
+      const errorResponse = NextResponse.json(
+        { error: 'Failed to fetch notifications' },
+        { status: 500 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    const { count: unreadCount, error: countError } = await adminClient
+      .from('admin_notifications')
+      .select('*', { count: 'exact', head: true })
+      .eq('admin_id', session.userId)
+      .eq('is_read', false)
+
+    if (countError) {
+      devError('Error counting unread notifications:', countError)
+    }
+
+    const successResponse = NextResponse.json({
+      notifications: notifications || [],
+      unread_count: unreadCount || 0,
+      total_count: count || 0,
+      limit,
+      offset,
+    })
+
+    return applySecurityHeaders(successResponse)
+  } catch (error) {
+    devError('Unexpected error in notifications endpoint:', error)
+    const errorResponse = NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+    return applySecurityHeaders(errorResponse)
+  }
+}


### PR DESCRIPTION
authenticate super admins and return their notifications with unread-first ordering, pagination, and counts.