### PR TITLE
feat: show unread notification badge in admin header

### DIFF
--- a/__tests__/app/super-admin-dashboard/notification-badge.test.tsx
+++ b/__tests__/app/super-admin-dashboard/notification-badge.test.tsx
@@ -1,0 +1,136 @@
+import SuperAdminDashboard from '@/app/super-admin-dashboard/page'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { createMockLocalStorage } from '../apply-tutor/__mocks__/localStorage'
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}))
+
+import { supabase } from '@/lib/supabase'
+
+const mockFrom = supabase.from as jest.MockedFunction<any>
+
+const createQuery = (resolved: { data?: any; error?: any }) => {
+  const query: any = {
+    eq: jest.fn(() => query),
+    order: jest.fn(() => query),
+    or: jest.fn(() => query),
+  }
+  query.then = (resolve: any, reject: any) =>
+    Promise.resolve({ data: [], error: null, ...resolved }).then(resolve, reject)
+  return query
+}
+
+const createHeadQuery = (count = 0) => {
+  const query: any = {
+    eq: jest.fn(() => query),
+  }
+  query.then = (resolve: any, reject: any) =>
+    Promise.resolve({ count, data: null, error: null }).then(resolve, reject)
+  return query
+}
+
+describe('Super Admin Dashboard Notification Badge', () => {
+  let mockStorage: ReturnType<typeof createMockLocalStorage>
+  let originalLocalStorage: Storage
+
+  beforeEach(() => {
+    mockStorage = createMockLocalStorage()
+    originalLocalStorage = global.localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: mockStorage,
+      writable: true,
+    })
+
+    mockStorage.setItem('superAdminLoggedIn', 'true')
+    mockStorage.setItem('superAdminEmail', 'admin@example.com')
+
+    mockFrom.mockImplementation((table: string) => ({
+      select: jest.fn((_: string, options?: { head?: boolean }) => {
+        if (table === 'profiles') {
+          return {
+            eq: jest.fn(() => ({
+              single: jest.fn().mockResolvedValue({
+                data: {
+                  id: 'admin-1',
+                  full_name: 'Super Admin',
+                  email: 'admin@example.com',
+                  role: 'super_admin',
+                },
+                error: null,
+              }),
+            })),
+          }
+        }
+
+        if (options?.head) {
+          return createHeadQuery(0)
+        }
+
+        return createQuery({ data: [], error: null })
+      }),
+    }))
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: originalLocalStorage,
+      writable: true,
+    })
+    jest.clearAllMocks()
+  })
+
+  it('shows unread count badge when notifications are present', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ unread_count: 5 }),
+    }) as jest.Mock
+
+    render(<SuperAdminDashboard />)
+
+    const bellButton = await screen.findByLabelText('5 unread notifications')
+    const badge = within(bellButton).getByText('5')
+    expect(badge).toBeInTheDocument()
+  })
+
+  it('does not render badge when unread count is zero', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ unread_count: 0 }),
+    }) as jest.Mock
+
+    render(<SuperAdminDashboard />)
+
+    const bellButton = await screen.findByLabelText('0 unread notifications')
+    expect(bellButton.querySelector('span')).toBeNull()
+  })
+
+  it('shows loading indicator while fetching notifications', async () => {
+    let resolveFetch: ((value: any) => void) | undefined
+    const fetchPromise = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+
+    global.fetch = jest.fn().mockReturnValue(fetchPromise) as jest.Mock
+
+    render(<SuperAdminDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Loading notifications')).toBeInTheDocument()
+    })
+
+    if (typeof resolveFetch !== 'function') {
+      throw new Error('resolveFetch was not set')
+    }
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({ unread_count: 0 }),
+    })
+
+    await screen.findByLabelText('0 unread notifications')
+  })
+})

--- a/app/super-admin-dashboard/page.tsx
+++ b/app/super-admin-dashboard/page.tsx
@@ -1,24 +1,20 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
-import {
-  UserGroupIcon,
-  AcademicCapIcon,
-  ClockIcon,
-  CurrencyDollarIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  ExclamationTriangleIcon,
-  ChartBarIcon,
-  CogIcon,
-  BellIcon,
-  ChevronDownIcon,
-  MagnifyingGlassIcon,
-  FunnelIcon,
-  ArrowRightOnRectangleIcon
-} from '@heroicons/react/24/outline'
 import { supabase } from '@/lib/supabase'
+import {
+  AcademicCapIcon,
+  ArrowRightOnRectangleIcon,
+  BellIcon,
+  ChartBarIcon,
+  ClockIcon,
+  CogIcon,
+  CurrencyDollarIcon,
+  ExclamationTriangleIcon,
+  UserGroupIcon,
+  XCircleIcon
+} from '@heroicons/react/24/outline'
+import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
 
 interface SuperAdminProfile {
   id: string
@@ -85,12 +81,56 @@ interface Student {
   }
 }
 
+function NotificationBadge({
+  count,
+  isLoading
+}: {
+  count: number
+  isLoading: boolean
+}) {
+  if (isLoading) {
+    return (
+      <div className="relative flex items-center">
+        <button
+          className="relative p-2 text-gray-600 hover:text-gray-900 transition-colors"
+          aria-label="Loading notifications"
+          disabled
+        >
+          <BellIcon className="w-6 h-6" />
+          <div className="absolute top-1 right-1 h-2 w-2 bg-gray-400 rounded-full animate-pulse" />
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative flex items-center">
+      <button
+        className="relative p-2 text-gray-600 hover:text-gray-900 transition-colors"
+        aria-label={`${count} unread notification${count !== 1 ? 's' : ''}`}
+        onClick={() => {
+          console.log('Open notifications')
+        }}
+      >
+        <BellIcon className={`w-6 h-6 ${count > 0 ? 'text-blue-600' : 'text-gray-600'}`} />
+        {count > 0 && (
+          <span className="absolute top-0 right-0 flex items-center justify-center min-w-[20px] h-5 px-1.5 text-xs font-bold text-white bg-red-500 rounded-full border-2 border-white">
+            {count > 99 ? '99+' : count}
+          </span>
+        )}
+      </button>
+    </div>
+  )
+}
+
 export default function SuperAdminDashboard() {
   const [userProfile, setUserProfile] = useState<SuperAdminProfile | null>(null)
   const [systemStats, setSystemStats] = useState<SystemStats | null>(null)
   const [activeSection, setActiveSection] = useState('overview')
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [isLoadingNotifications, setIsLoadingNotifications] = useState(false)
 
   // Data states
   const [tutors, setTutors] = useState<Tutor[]>([])
@@ -130,6 +170,20 @@ export default function SuperAdminDashboard() {
       fetchTutors()
     }
   }, [tutorFilter, searchTerm])
+
+  useEffect(() => {
+    if (!userProfile) {
+      return
+    }
+
+    fetchUnreadCount()
+
+    const interval = setInterval(() => {
+      fetchUnreadCount()
+    }, 30000)
+
+    return () => clearInterval(interval)
+  }, [userProfile])
 
   const checkSuperAdminStatus = async () => {
     try {
@@ -174,6 +228,36 @@ export default function SuperAdminDashboard() {
       setError('Failed to verify super admin status')
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  const fetchUnreadCount = async () => {
+    if (!userProfile) {
+      return
+    }
+
+    try {
+      setIsLoadingNotifications(true)
+
+      const response = await fetch('/api/admin/notifications?unread_only=true&limit=1', {
+        method: 'GET',
+        credentials: 'include'
+      })
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          console.warn('Not authorized to fetch notifications')
+          return
+        }
+        throw new Error(`Failed to fetch notifications: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setUnreadCount(data.unread_count || 0)
+    } catch (err) {
+      console.error('Error fetching unread count:', err)
+    } finally {
+      setIsLoadingNotifications(false)
     }
   }
 
@@ -1042,6 +1126,7 @@ export default function SuperAdminDashboard() {
               <h1 className="text-2xl font-bold text-gray-900">Super Admin Dashboard</h1>
             </div>
             <div className="flex items-center space-x-4">
+              <NotificationBadge count={unreadCount} isLoading={isLoadingNotifications} />
               <div className="text-right">
                 <p className="text-sm text-gray-500">Super Admin</p>
                 <p className="font-medium text-gray-900">{userProfile?.full_name}</p>


### PR DESCRIPTION
fetch unread counts from the admin notifications API and render a bell badge with loading state and refresh interval.