### PR TITLE
feat: mark admin notifications as read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: npm run lint
 
       - name: Test
+        env:
+          NODE_ENV: test
         run: npm test
 
       - name: Build

--- a/__tests__/app/api/admin/notifications/read/route.test.ts
+++ b/__tests__/app/api/admin/notifications/read/route.test.ts
@@ -1,0 +1,275 @@
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: jest.fn(),
+  },
+}))
+
+jest.mock('@/lib/session-management')
+jest.mock('@/lib/services/security-headers-service')
+jest.mock('@/lib/utils/logger', () => ({
+  devError: jest.fn(),
+  devLog: jest.fn(),
+}))
+
+import { PATCH } from '@/app/api/admin/notifications/[id]/read/route'
+import { applySecurityHeaders } from '@/lib/services/security-headers-service'
+import { getSessionFromRequest } from '@/lib/session-management'
+import { supabaseAdmin } from '@/lib/supabase'
+
+const adminClient = supabaseAdmin as NonNullable<typeof supabaseAdmin>
+const mockFrom = adminClient.from as jest.MockedFunction<any>
+const mockGetSession = getSessionFromRequest as jest.MockedFunction<typeof getSessionFromRequest>
+const mockApplySecurityHeaders = applySecurityHeaders as jest.MockedFunction<typeof applySecurityHeaders>
+
+const createRequest = (id: string) =>
+  new NextRequest(`http://localhost:3000/api/admin/notifications/${id}/read`, {
+    method: 'PATCH',
+  })
+
+describe('PATCH /api/admin/notifications/[id]/read', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApplySecurityHeaders.mockImplementation((response) => response as any)
+  })
+
+  it('returns 503 when admin client is unavailable', async () => {
+    const supabaseModule = jest.requireMock('@/lib/supabase') as {
+      supabaseAdmin: { from: jest.Mock } | null
+    }
+    const originalAdmin = supabaseModule.supabaseAdmin
+    supabaseModule.supabaseAdmin = null
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Service temporarily unavailable' })
+
+    supabaseModule.supabaseAdmin = originalAdmin
+  })
+
+  it('returns 401 when no session is present', async () => {
+    mockGetSession.mockReturnValue(null)
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Unauthorized - Please login first' })
+  })
+
+  it('returns 403 when session is not super_admin', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'user-1',
+      email: 'user@example.com',
+      role: 'parent',
+      fullName: 'User',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Forbidden - Admin access required' })
+  })
+
+  it('returns 400 for invalid UUID format', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const res = await PATCH(createRequest('not-a-uuid'), {
+      params: { id: 'not-a-uuid' },
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Invalid notification ID format' })
+  })
+
+  it('returns 404 when notification is not found', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+    }))
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Notification not found' })
+  })
+
+  it('returns 403 when admin does not own the notification', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 'notif-1', admin_id: 'other-admin', is_read: false },
+        error: null,
+      }),
+    }))
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Forbidden - You can only mark your own notifications as read' })
+  })
+
+  it('returns success when notification is already read', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    mockFrom.mockImplementation(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 'notif-1', admin_id: 'admin-1', is_read: true },
+        error: null,
+      }),
+    }))
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      success: true,
+      message: 'Notification already marked as read',
+    })
+  })
+
+  it('returns 500 when update fails', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    mockFrom
+      .mockImplementationOnce(() => ({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { id: 'notif-1', admin_id: 'admin-1', is_read: false },
+          error: null,
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        update: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: null, error: { message: 'update failed' } }),
+      }))
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Failed to update notification' })
+  })
+
+  it('marks notification as read successfully', async () => {
+    mockGetSession.mockReturnValue({
+      userId: 'admin-1',
+      email: 'admin@example.com',
+      role: 'super_admin',
+      fullName: 'Admin',
+      phone: '123',
+      isActive: true,
+      createdAt: Date.now(),
+    })
+
+    const updatedNotification = {
+      id: 'notif-1',
+      admin_id: 'admin-1',
+      is_read: true,
+      read_at: new Date().toISOString(),
+    }
+
+    mockFrom
+      .mockImplementationOnce(() => ({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({
+          data: { id: 'notif-1', admin_id: 'admin-1', is_read: false },
+          error: null,
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        update: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        single: jest.fn().mockResolvedValue({ data: updatedNotification, error: null }),
+      }))
+
+    const res = await PATCH(createRequest('00000000-0000-0000-0000-000000000000'), {
+      params: { id: '00000000-0000-0000-0000-000000000000' },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      success: true,
+      notification: updatedNotification,
+    })
+  })
+})

--- a/app/api/admin/notifications/[id]/read/route.ts
+++ b/app/api/admin/notifications/[id]/read/route.ts
@@ -1,0 +1,128 @@
+import { applySecurityHeaders } from '@/lib/services/security-headers-service'
+import { getSessionFromRequest } from '@/lib/session-management'
+import { supabaseAdmin } from '@/lib/supabase'
+import { devError, devLog } from '@/lib/utils/logger'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const adminClient = supabaseAdmin
+    if (!adminClient) {
+      devError('Supabase admin client not available')
+      const errorResponse = NextResponse.json(
+        { error: 'Service temporarily unavailable' },
+        { status: 503 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    const session = getSessionFromRequest(request)
+    if (!session) {
+      const unauthorizedResponse = NextResponse.json(
+        { error: 'Unauthorized - Please login first' },
+        { status: 401 }
+      )
+      return applySecurityHeaders(unauthorizedResponse)
+    }
+
+    if (session.role !== 'super_admin') {
+      const forbiddenResponse = NextResponse.json(
+        { error: 'Forbidden - Admin access required' },
+        { status: 403 }
+      )
+      return applySecurityHeaders(forbiddenResponse)
+    }
+
+    const notificationId = params.id
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(notificationId)) {
+      const errorResponse = NextResponse.json(
+        { error: 'Invalid notification ID format' },
+        { status: 400 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    const { data: existingNotification, error: fetchError } = await adminClient
+      .from('admin_notifications')
+      .select('id, admin_id, is_read')
+      .eq('id', notificationId)
+      .single()
+
+    if (fetchError || !existingNotification) {
+      devError('Notification not found:', fetchError)
+      const errorResponse = NextResponse.json(
+        { error: 'Notification not found' },
+        { status: 404 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    if (existingNotification.admin_id !== session.userId) {
+      devError('Admin tried to mark notification they do not own')
+      const forbiddenResponse = NextResponse.json(
+        { error: 'Forbidden - You can only mark your own notifications as read' },
+        { status: 403 }
+      )
+      return applySecurityHeaders(forbiddenResponse)
+    }
+
+    if (existingNotification.is_read) {
+      devLog('Notification already marked as read')
+      const successResponse = NextResponse.json({
+        success: true,
+        message: 'Notification already marked as read',
+      })
+      return applySecurityHeaders(successResponse)
+    }
+
+    const { data, error } = await adminClient
+      .from('admin_notifications')
+      .update({
+        is_read: true,
+        read_at: new Date().toISOString(),
+      })
+      .eq('id', notificationId)
+      .eq('admin_id', session.userId)
+      .select()
+      .single()
+
+    if (error) {
+      devError('Error marking notification as read:', error)
+      const errorResponse = NextResponse.json(
+        { error: 'Failed to update notification' },
+        { status: 500 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    if (!data) {
+      const errorResponse = NextResponse.json(
+        { error: 'Notification not found or already updated' },
+        { status: 404 }
+      )
+      return applySecurityHeaders(errorResponse)
+    }
+
+    devLog(`Notification ${notificationId} marked as read by admin ${session.userId}`)
+
+    const successResponse = NextResponse.json({
+      success: true,
+      notification: data,
+    })
+
+    return applySecurityHeaders(successResponse)
+  } catch (error) {
+    devError('Unexpected error in mark as read endpoint:', error)
+    const errorResponse = NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+    return applySecurityHeaders(errorResponse)
+  }
+}

--- a/app/super-admin-dashboard/page.tsx
+++ b/app/super-admin-dashboard/page.tsx
@@ -124,16 +124,22 @@ function getTimeAgo(timestamp: string): string {
 
 function NotificationItem({
   notification,
-  onClick,
+  onMarkAsRead,
 }: {
   notification: AdminNotification
-  onClick: () => void
+  onMarkAsRead: (id: string) => void
 }) {
   const timeAgo = getTimeAgo(notification.created_at)
 
+  const handleClick = () => {
+    if (!notification.is_read) {
+      onMarkAsRead(notification.id)
+    }
+  }
+
   return (
     <li
-      onClick={onClick}
+      onClick={handleClick}
       className={`
         px-4 py-3 cursor-pointer transition-colors
         ${!notification.is_read ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'}
@@ -174,12 +180,14 @@ function NotificationsDropdown({
   isLoading,
   unreadCount,
   onClose,
+  onMarkAsRead,
 }: {
   isOpen: boolean
   notifications: AdminNotification[]
   isLoading: boolean
   unreadCount: number
   onClose: () => void
+  onMarkAsRead: (id: string) => void
 }) {
   useEffect(() => {
     if (!isOpen) return
@@ -239,9 +247,7 @@ function NotificationsDropdown({
               <NotificationItem
                 key={notification.id}
                 notification={notification}
-                onClick={() => {
-                  onClose()
-                }}
+                onMarkAsRead={onMarkAsRead}
               />
             ))}
           </ul>
@@ -486,6 +492,46 @@ export default function SuperAdminDashboard() {
       fetchNotifications()
     }
     setIsDropdownOpen((prev) => !prev)
+  }
+
+  const markAsRead = async (notificationId: string) => {
+    if (!userProfile) {
+      return
+    }
+
+    const notification = notifications.find((item) => item.id === notificationId)
+    if (notification?.is_read) {
+      return
+    }
+
+    const optimisticReadAt = new Date().toISOString()
+    setNotifications((prev) =>
+      prev.map((item) =>
+        item.id === notificationId
+          ? { ...item, is_read: true, read_at: optimisticReadAt }
+          : item
+      )
+    )
+    setUnreadCount((prev) => Math.max(0, prev - 1))
+
+    try {
+      const response = await fetch(`/api/admin/notifications/${notificationId}/read`, {
+        method: 'PATCH',
+        credentials: 'include'
+      })
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          console.warn('Not authorized to mark notification as read')
+          await Promise.all([fetchNotifications(), fetchUnreadCount()])
+          return
+        }
+        throw new Error(`Failed to mark as read: ${response.status}`)
+      }
+    } catch (error) {
+      console.error('Error marking notification as read:', error)
+      await Promise.all([fetchNotifications(), fetchUnreadCount()])
+    }
   }
 
   const fetchSystemStats = async () => {
@@ -1365,6 +1411,7 @@ export default function SuperAdminDashboard() {
                   isLoading={isFetchingNotifications}
                   unreadCount={unreadCount}
                   onClose={() => setIsDropdownOpen(false)}
+                  onMarkAsRead={markAsRead}
                 />
               </div>
               <div className="text-right">


### PR DESCRIPTION
Add a mark-as-read API route, cover it with tests, and wire notification clicks to update read state in the dashboard.