### PR TITLE
fix: refetch admin requests on filter change

### DIFF
--- a/app/super-admin-dashboard/page.tsx
+++ b/app/super-admin-dashboard/page.tsx
@@ -375,6 +375,12 @@ export default function SuperAdminDashboard() {
   }, [tutorFilter, searchTerm])
 
   useEffect(() => {
+    if (userProfile) {
+      fetchRequests()
+    }
+  }, [requestFilter, userProfile])
+
+  useEffect(() => {
     if (!userProfile) {
       return
     }


### PR DESCRIPTION
Trigger request reload when the admin request filter updates so the list matches the selected status.