### PR TITLE
feat: Phase 2–3 API contract, CI hardening, Caddy on :80, EC2 deploy

### DIFF
--- a/.cursor/rules/se46-context.mdc
+++ b/.cursor/rules/se46-context.mdc
@@ -1,0 +1,384 @@
+---
+description: SE_46 Web Backend Technologies project context. Always load when working on Tutor-Link. Defines the grading rubric, framing constraints, code conventions, and evidence criteria Cursor must optimize the codebase toward.
+alwaysApply: true
+---
+
+# Tutor-Link — SE_46 Project Context
+
+You are helping drive this project toward **Level 2/3** on the SE_46 Web Backend Technologies rubric at CODE Berlin. Every suggestion you make must defensibly move the codebase toward at least one of the 8 Qualification Objectives (QOs) below, without regressing what is already strong.
+
+---
+
+## 1. What Tutor-Link Is
+
+A web platform that connects parents with qualified in-home tutors. Two primary flows:
+
+1. **Parent flow** — multi-step signup form → OTP email verification → Supabase account creation → home-tutoring request persisted.
+2. **Tutor flow** — application with qualifications and availability → admin review → matching.
+
+Additional surfaces: admin dashboards (matching, notifications, stats, tutor management), session lifecycle (accept/change/cancel), messaging between matched parents and tutors.
+
+The author (Thomas, CODE student) is submitting this as the main assessed project for SE_46.
+
+## 2. Tech Stack
+
+- **Framework:** Next.js 14 (App Router) — single monolith, no separate backend service.
+- **Language:** TypeScript 5, `strict: true`.
+- **DB / Auth:** Supabase (PostgreSQL, Row-Level Security, Supabase Auth for OTP/magic links).
+- **UI libs:** Tailwind CSS, Headless UI, Lucide React, Framer Motion.
+- **Security libs:** bcryptjs (password hashing), custom HMAC-SHA256 CSRF.
+- **Testing:** Jest + Testing Library. Tests live under [`__tests__/`](__tests__/) (API route integration tests, apply-tutor flows, etc.). **Gap vs §8:** coverage is still light on [`lib/services/*`](lib/services/) — target **≥60%** on `lib/` with unit tests co-located as `*.test.ts` where practical.
+- **CI/CD:** [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs **lint, test, build** on `master` / `dev` (uses repo secrets for Supabase env in CI). **Gap:** no `typecheck` or `npm audit` step yet.
+
+## 3. Grading Rubric — The 8 Qualification Objectives
+
+Every change should be traceable to at least one of these. At assessment, Sam Boguslawski will ask *"Does this project demonstrate X?"* for each:
+
+1. **QO1** — Build and deploy complex, stable backend applications.
+2. **QO2** — Choose and apply the most suitable software and server architectures (monolith, microservices, containers).
+3. **QO3** — Identify, select, and use the most appropriate programming language, framework, and development tools.
+4. **QO4** — Design and build a scalable API ready for multi-client consumption (API design, error handling).
+5. **QO5** — Identify and utilize the most appropriate methods of building scalable and stateful backends (databases).
+6. **QO6** — Write maintainable backend code (design patterns, tests, monitoring & logging, version control, documentation).
+7. **QO7** — Apply appropriate measures of authentication, authorization, and general web security.
+8. **QO8** — Design backend architectures optimized for performance and horizontal/vertical scalability (load testing, caching).
+
+### Level 2/3 ≠ Level 0/1
+
+- **Level 0/1 (pass):** All 8 QOs shown at minimum viable depth.
+- **Level 2/3 (high grade):** Critical architectural decisions are *explicitly reasoned*, code quality is high, the project "constructively contributes to the field of backend engineering." Every QO needs **evidence and rationale**, not just presence.
+
+Level 2/3 is the target. Presence of a tool is not enough — the project must *show why* that tool is appropriate and *how* its limits were considered.
+
+## 4. CRITICAL CONSTRAINT — The Next.js Framing Risk
+
+> The rubric explicitly warns that Next.js is a poor fit for SE_46 because "backend code takes a back seat." The assessor's litmus test is: *"Could you build and scale a backend without a frontend hosted on a custom server and not on Vercel?"*
+
+This project is currently 100% Next.js on Vercel. The grade will suffer unless the backend is demonstrably **portable and standalone**. Any changes you propose must either:
+
+- **Strengthen portability** — separate backend concerns from Next.js-specific APIs, add Dockerfile, make the backend deployable as its own container on any Linux host, OR
+- **Be neutral to portability** — not deepen coupling to Vercel/Next.js.
+
+**Never introduce new dependencies on Vercel-specific features** (Vercel KV, Vercel Postgres, Vercel Cron, Edge Config, `@vercel/*` packages) unless the user explicitly opts in. If tempted, propose a portable alternative first (standard Redis, standard Postgres, standard cron via a worker container, etc.).
+
+When asked to add features, always mentally ask: *"If we deleted Vercel and redeployed as `docker compose up`, would this still work?"* If no, flag it and propose the portable path.
+
+## 4.5. Architectural Decision (Committed): Modular Monolith
+
+This is a **committed** decision. It is not open for re-litigation in the course of day-to-day work. It is recorded formally in `docs/ADR/0001-modular-monolith.md`.
+
+### The decision, stated
+
+Tutor-Link is a **modular monolith**. It runs as a **single deployable unit**. Module boundaries are enforced at `lib/services/*` — one service per cohesive capability (auth, registration, CSRF, rate limiting, account creation, matching, notifications, sessions, messaging). The HTTP layer (`app/api/*`) is a **thin adapter** over these services and owns no business logic.
+
+The project is **deployment-portable**. The reference deployment is Vercel (for the frontend + API), but a `Dockerfile` + `docker-compose.yml` allows the same code to run on any container host (Railway, Fly.io, Render, DigitalOcean, a bare VM). Portability is a first-class constraint — see §4.
+
+### Why monolith (not microservices)
+
+- The domain has a single consistency boundary (a parent, a tutor, a session, a match are all tightly related). Splitting into services would manufacture distributed-transaction problems that don't exist today.
+- The team is one person. Microservices require org-scale justification.
+- The QO2 rubric rewards *reasoned choice*, not service count. A defended monolith scores higher than an undefended microservice split.
+- Module seams already exist at `lib/services/*`. If a single module ever reaches independent scaling requirements (unlikely at current scale), it can be extracted — but only then, and only with an ADR.
+
+### What this means operationally
+
+**Module boundaries are real.** Cross-service imports in `lib/services/*` are discouraged. When service A needs service B's capability, it:
+1. Imports B's public result types and calls its exported functions (preferred), or
+2. Depends on an interface and receives B (or a test double) via parameter injection.
+
+**No service may reach into another service's internal helpers.** If a helper is needed by two services, promote it to `lib/utils/` or a shared module.
+
+**The HTTP layer owns no business logic.** A route handler does: origin → body → CSRF → rate-limit → sanitize → validate → authorize → *call a service* → respond. If a route file contains domain logic, that logic is in the wrong place.
+
+**One deployable unit.** No queues, no event buses, no separate worker processes unless a specific feature demonstrably requires async work — in which case, add an ADR justifying the new process and keep it inside the same repo + docker-compose.
+
+**Scaling is horizontal replicas of the same process.** This is why rate-limit state, session state, and any cache must move to Redis (see §8 QO8). In-process state is a monolith smell; stateless replicas are the goal.
+
+### What this rules out
+
+- Extracting `ai-matching-service/` into its own service. (It stays a module under `lib/services/`.)
+- Introducing a message broker (Kafka, RabbitMQ, SQS) without an ADR and a concrete scaling justification.
+- Splitting auth, sessions, or matching into independent deployables.
+- "Just in case" interfaces that pretend services are remote when they aren't.
+
+### What this still requires you to do
+
+Committing to monolith does **not** remove the QO1/QO8 Docker + Redis + load-test work. Those are separate axes:
+- Monolith/microservices → **service count** (decided: monolith).
+- Vercel-only/portable → **deployment portability** (work required: Dockerfile, docker-compose, non-Vercel deploy).
+- In-process state/stateless → **horizontal scalability** (work required: Redis for rate-limit and any cache).
+
+All three must be addressed. §8 lists the concrete artifacts per QO.
+
+### Viva-ready framing
+
+At the SE_46 viva, when asked "why a monolith?" or "why not microservices?", the answer is:
+
+> Tutor-Link is a single-bounded-context domain with one deployable unit. Microservices would introduce network boundaries without corresponding organizational or scaling boundaries. I committed to a **modular monolith** with enforced module seams at `lib/services/*` and made the deployment portable via Docker so the monolith decision doesn't couple me to any one host. If any single module ever required independent scaling, extraction is straightforward because the seams already exist. Today, it doesn't, so it shouldn't.
+
+Cursor should reinforce this framing — not hedge it — in any generated comments, docs, or ADRs.
+
+## 5. Current State Assessment (Baseline)
+
+The full assessment lives at `D:\alphalist-frontend\study\SE_46_project_assessment.md`. Condensed:
+
+**Grades by QO (baseline):**
+| QO | Grade | Why |
+|---|---|---|
+| 1 | Adequate | Works but Vercel-only |
+| 2 | Adequate | Sensible choices, but no documented reasoning |
+| 3 | Weak–Adequate | Jest + CI tests exist; **no `typecheck` in CI**; tool chain (Husky, Prettier doc) thin |
+| 4 | Adequate | REST works; no versioning, no OpenAPI, inconsistent errors |
+| 5 | Adequate | Good schema + RLS; no caching, no query profiling |
+| 6 | Strong (minus depth) | Great docs + service layer; **some** tests — service-layer coverage and structured logging still below L2/3 bar |
+| 7 | **Strong** | CSRF, account lockout, sanitization, threat model |
+| 8 | Weak | Relies on Vercel auto-scaling; no Docker, no load testing; rate limits use **Postgres `rate_limits`** (shared) with **in-memory fallback** on DB errors — still not the Redis/stateless replica story §8 calls for |
+
+**Overall estimated level:** high Level 1 / low Level 2.
+
+## 6. Strengths — DO NOT DEGRADE
+
+These patterns are working and must be preserved unless a change explicitly improves them:
+
+### Security (QO7)
+- CSRF via `lib/services/csrf-service.ts` using HMAC-SHA256 tokens in httpOnly cookies. Validate via `validateCSRFRequest(req, csrf_token)` at the top of state-changing route handlers.
+- Input validation via `lib/security.ts` (`validateEmailDetailed`, `validatePhoneDetailed`, `validateCountryCode`).
+- Input sanitization via `lib/services/input-sanitization-service.ts` (`sanitizeFormData`).
+- Rate limiting via `lib/server-rate-limiting.ts` (`checkServerSideRateLimit`). **Implementation:** primary path persists counters in Supabase **`rate_limits`** (Postgres); **fallback** is in-memory when the admin client or DB operations fail — that path is not safe across replicas. **Rubric target:** Redis or a documented ADR (Postgres counters vs Redis) per QO7/QO8.
+- Account lockout via `lib/account-lockout.ts`.
+- Security headers via `lib/services/security-headers-service.ts` (`applySecurityHeaders`).
+- Session cookies: httpOnly, secure, SameSite=Strict in production (see `lib/session-management.ts`).
+- Threat model documented at `docs/THREAT_MODEL.md` and `docs/PARENT_WORKFLOW_THREAT_MODEL.md`.
+
+### Code organization (QO6)
+- Service layer in `lib/services/` with `*-service.ts` naming.
+- Utilities in `lib/utils/` (logger, account-check, redirect-url, supabase-auth-errors, tutor-data-transformation).
+- Shared types in `lib/session-types.ts`, `lib/message-types.ts`, `lib/enhanced-tutor-types.ts`.
+- Error messages and registration types centralized in `lib/constants.ts`.
+- Custom error handling in `lib/error-handling.ts`.
+- Import path alias: `@/lib/...`, `@/app/...`.
+
+### Documentation (QO6)
+- `docs/` contains 15+ Markdown files covering architecture, API, data model, threat model, contributing, testing error messages, infrastructure improvements.
+- Keep documentation in sync with code changes. When you add a capability, add or update the corresponding doc.
+
+## 7. Code Conventions — Patterns You Must Follow
+
+### Canonical API route handler structure
+
+When creating/editing a POST/PUT/PATCH/DELETE route in `app/api/**/route.ts`, follow this exact order:
+
+```ts
+export async function POST(req: NextRequest) {
+  try {
+    // 1. Origin check (for state-changing requests)
+    const origin = req.headers.get('origin') || ''
+    if (!isOriginAllowed(origin)) {
+      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
+    }
+
+    // 2. Parse body (JSON error → 400)
+    let body: RequestBody
+    try {
+      body = await req.json()
+    } catch {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_JSON }, { status: 400 })
+    }
+
+    // 3. CSRF validation
+    const csrfValidation = validateCSRFRequest(req, body.csrf_token)
+    if (!csrfValidation.isValid) { /* 403 */ }
+
+    // 4. Rate limiting
+    const rateLimit = await checkServerSideRateLimit(/* ... */)
+    if (!rateLimit.allowed) { /* 429 */ }
+
+    // 5. Sanitize input
+    const sanitized = sanitizeFormData(body.formData)
+
+    // 6. Validate input (business rules)
+    const validation = validateFormData(sanitized)
+    if (!validation.isValid) { /* 400 */ }
+
+    // 7. Authorize (role check, ownership check) — where applicable
+
+    // 8. Perform the work (delegate to a service in lib/services/)
+
+    // 9. Build response + apply security headers
+    const res = NextResponse.json({ ok: true })
+    applySecurityHeaders(res)
+    return res
+  } catch (error) {
+    devError('Route error:', error)
+    return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_SERVER_ERROR }, { status: 500 })
+  }
+}
+```
+
+If you skip any step, justify it in a comment. Silent omissions are not acceptable.
+
+### Service pattern
+
+New business logic goes in `lib/services/{feature}-service.ts`. Services must:
+- Be side-effect isolated (take dependencies as params where practical, to aid testing).
+- Have a top-of-file JSDoc block listing "Clean Code Principles Applied" with Single Responsibility / Testability / Error Handling bullets (existing convention — follow it).
+- Export typed result objects (`{ isValid: boolean; error?: string }` or discriminated unions), not raw booleans or thrown strings.
+- Return `Promise<Result>` where async; never throw for expected failure cases.
+
+### Type conventions
+- Prefer `interface` for object shapes used across files; `type` for unions, intersections, and utility types.
+- Domain types live in dedicated files (`session-types.ts`, `message-types.ts`, etc.), not beside route handlers.
+- No `any`. If you truly need it, use `unknown` + a type guard.
+
+### Error response shape — **standardize this**
+Legacy routes may still return `{ error: "string" }`. **New and modified routes must use the richer envelope** via `apiErrorResponse` in `lib/services/api-error-response-service.ts`:
+```ts
+{ error: { code: "RATE_LIMITED", message: "Too many requests", details?: {...} } }
+```
+Machine-readable codes: `lib/api-error-codes.ts`. Human copy often comes from `ERROR_MESSAGES` in `lib/constants.ts`. Clients should parse with `getApiErrorMessage` in `lib/utils/api-client-error.ts` until all routes are migrated. See `docs/API_errors.md` and `docs/openapi.yaml` (schema `Error`).
+
+### Logging
+- Use `devError` / `devLog` from `lib/utils/logger.ts` for dev-only logs.
+- For production-safe logging, emit structured JSON to stdout (this is the target pattern — introduce `lib/utils/structured-logger.ts` when needed, do not log unstructured strings in production paths).
+- Never log secrets, passwords, full session tokens, CSRF tokens, or raw request bodies.
+
+### Testing (when you write tests)
+- Tests live next to code as `*.test.ts` for unit tests (e.g. `lib/services/csrf-service.test.ts`).
+- Integration tests for route handlers live in `__tests__/api/` mirroring the route structure.
+- Use Jest + ts-jest. No `describe` nesting deeper than 2 levels. Test names read as sentences: `it('returns 403 when origin is not allowed', ...)`.
+- Never mock what you own — mock external boundaries (Supabase client, crypto RNG where needed) and test real logic.
+
+### Git & commits
+- Trunk-based. Short-lived feature branches merged via PR.
+- Commit messages: Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`).
+- Subject line ≤ 72 chars, imperative mood, no trailing period.
+
+## 8. What "Level 2/3 Evidence" Looks Like Per QO
+
+When proposing changes, target these concrete artifacts. Presence of these items in the repo is what Sam will grade.
+
+### QO1 — Build & deploy complex, stable backend apps
+- Dockerfile that builds a runnable image without Vercel.
+- `docker-compose.yml` running the app + a local Postgres (or a dev Supabase compose) + Redis.
+- Documented deploy target other than Vercel (Railway, Fly.io, Render, etc.) with working deployment.
+- Health-check endpoint (`/api/health` returning 200 + version + DB connectivity).
+- Graceful shutdown handling where applicable.
+
+### QO2 — Choose architectures
+- `docs/ADR/` directory with Architecture Decision Records (ADRs) in Michael Nygard format. **ADR-0001 (modular monolith)** is committed and must exist. Additional required ADRs: deployment portability (Docker + non-Vercel target), Supabase vs self-hosted Postgres + Auth0, Next.js vs Express/NestJS, synchronous vs queue-based notifications, in-memory vs Redis rate limiting.
+- At least one diagram (Mermaid or exported image) showing system boundaries and module seams inside the monolith.
+- Trade-off analysis written out, not just a decision. Each ADR includes Context, Decision, Status, Consequences, and at least one rejected alternative.
+
+### QO3 — Choose language/framework/tools
+- An ADR justifying TypeScript + Next.js vs alternatives, with explicit criteria (type safety, ecosystem, team familiarity, deployment options).
+- Non-trivial tool configuration visible: strict TS config (already present), ESLint rules documented, Prettier config, Husky pre-commit hooks running lint + typecheck + tests.
+- `package.json` scripts for `typecheck`, `lint`, `test`, `test:coverage`.
+
+### QO4 — Scalable API for multi-client consumption
+- API versioning visible in URLs (`/api/v1/...`) OR via `Accept` header with a versioning strategy documented.
+- OpenAPI spec at `docs/openapi.yaml` or auto-generated from route handlers.
+- Consistent error response shape across every route (see §7).
+- Pagination, filtering, and sorting on every list endpoint that can grow.
+- Documented rate limits per endpoint (X-RateLimit-* headers in responses).
+- CORS rules justified in `docs/API_*.md`.
+
+### QO5 — Scalable stateful backend (databases)
+- Documented indexing strategy (in `docs/DATA_*.md`) for each non-trivial table.
+- Query profiling evidence — at least one note like "this query is supported by index X; verified with EXPLAIN ANALYZE."
+- Transaction boundaries explicit where multi-row writes happen (`lib/services/account-creation-service.ts` is a good place to demonstrate this).
+- Migration/schema history tracked (if using Supabase migrations, commit the SQL files; otherwise add a `migrations/` folder).
+- Caching layer (even minimal: Redis or LRU in-memory cache for a justified hot path) with invalidation rules documented.
+
+### QO6 — Maintainable code
+- Test coverage ≥ 60% on `lib/` (service layer). Start with CSRF, rate limiting, auth, validation, registration services.
+- CI pipeline (GitHub Actions) running lint + typecheck + tests on every PR.
+- Structured logging in place (JSON logs, log levels, no raw `console.log` in production paths).
+- Every public function in `lib/services/*` has JSDoc.
+- `docs/` kept in sync — when a capability ships, the corresponding API/data doc is updated in the same PR.
+
+### QO7 — Authentication, authorization, security
+- Already Strong. To reach Level 2/3:
+  - **Rate-limit store:** primary is already **Postgres** (not single-process memory). For §8, either **add Redis** for counters/cache/session/idempotency or **ADR** why Postgres counters + removing fail-open-to-memory behavior is enough; eliminate or narrow the in-memory fallback if you claim full horizontal consistency.
+  - Add dependency scanning (`npm audit` in CI + Dependabot/Renovate).
+  - Add SAST scan (CodeQL or Semgrep GitHub Action) with results committed to `docs/SECURITY_SCAN_REPORT.md` per release.
+  - Add an `.env.example` that documents every required secret.
+  - Verify HSTS and all security headers with a run through `securityheaders.com` and commit the report.
+
+### QO8 — Performance & scalability
+- Dockerfile (from QO1) makes the app horizontally scalable.
+- Stateless design — session state, rate-limit state, and idempotency tokens live in Redis, not process memory.
+- Load test script (`tests/load/*.js` using k6 or Artillery) + results committed in `docs/LOAD_TEST_REPORT.md` (100/1000/10000 concurrent users on each major endpoint).
+- Caching for read-heavy endpoints (tutor lists, match candidates) with documented invalidation.
+- Database connection pooling tuned (explicit pool size decision, not a default).
+- CDN headers for static assets; API response cache headers where appropriate.
+
+## 9. Hard Do / Don't Rules
+
+**DO**
+- Follow the canonical route handler structure in §7 for every state-changing endpoint.
+- Use the richer error response shape (`{ error: { code, message } }`) for new and modified routes.
+- Put new business logic in `lib/services/*-service.ts`, not in route files.
+- Update the relevant `docs/*.md` in the same PR that changes behavior.
+- When introducing a significant dependency, write an ADR for it in `docs/ADR/`.
+- Ask "does this survive without Vercel?" for every infrastructure-touching change.
+
+**DON'T**
+- Don't bypass the security stack (CSRF, origin, sanitize, validate, rate-limit). If a new route legitimately doesn't need one of these, add a code comment explaining why.
+- Don't introduce Vercel-specific services (Vercel KV, Vercel Postgres, Vercel Cron, Edge Config, `@vercel/*`) without explicit approval.
+- Don't add `any`, `// @ts-ignore`, or `// @ts-expect-error` without a paired TODO and a ticket-worthy reason.
+- Don't log secrets, raw bodies, CSRF tokens, session tokens, or passwords — even in dev-only paths.
+- Don't add new routes without corresponding API docs in `docs/API_*.md`.
+- Don't regress test coverage. If you modify a tested module, keep or increase coverage.
+- Don't introduce new error response shapes. Migrate old ones to the standard shape instead.
+- Don't invent libraries — prefer existing ones already in `package.json` or well-established, maintained packages with > 1M weekly downloads where reasonable.
+- Don't write React/UI code to satisfy backend QOs. This is a backend module; frontend changes should be incidental, not the primary deliverable for any QO.
+
+## 10. File Location Map
+
+```
+app/
+  api/                     → route handlers (HTTP boundary). Keep THIN.
+  (pages)                  → UI. Backend QOs are not won here.
+lib/
+  services/*-service.ts    → business logic. Write tests here first.
+  utils/                   → small helpers.
+  constants.ts             → error messages, enums, magic strings.
+  error-handling.ts        → custom error types.
+  security.ts              → validators (email, phone, country code).
+  session-management.ts    → session cookies, signing.
+  server-rate-limiting.ts  → rate limiter (Postgres `rate_limits` + in-memory fallback; target: Redis or ADR’d Postgres-only + safer fallback).
+  account-lockout.ts       → lockout logic.
+  registration-storage.ts  → pending registration persistence.
+  supabase.ts              → Supabase client factory + redirect URL helper.
+  cors-config.ts           → allowed origins.
+docs/
+  API_*.md                 → endpoint documentation (update with every route change).
+  DATA_*.md                → data model and indexing rationale.
+  THREAT_MODEL.md          → security threat analysis.
+  ADR/                     → Architecture Decision Records (`0001-modular-monolith.md` committed; add more per §8).
+  openapi.yaml             → (to be created) machine-readable API spec.
+  LOAD_TEST_REPORT.md      → (to be created) load test results per release.
+__tests__/                 → Jest integration + unit tests (mirror `app/api/` where applicable).
+tests/                     → (optional) load tests e.g. k6/Artillery — create when adding §8 evidence.
+```
+
+## 11. Glossary
+
+- **Assessor / Sam** — Samuel Boguslawski, module instructor. Will run the project viva.
+- **QO** — Qualification Objective (one of the 8).
+- **ADR** — Architecture Decision Record (Michael Nygard format: Context, Decision, Status, Consequences).
+- **Canonical route structure** — the 9-step pattern in §7.
+- **Portability test** — the mental check: "does this survive deletion of Vercel?"
+- **Level 2/3** — high-grade target. Requires *evidence and rationale*, not just presence.
+
+## 12. When In Doubt
+
+If a user request conflicts with these rules (e.g., "just add a Vercel KV cache real quick"), surface the conflict:
+
+> This would deepen Vercel coupling and regress the portability target. Alternatives: (a) add a standard Redis instance, (b) use an in-memory LRU and accept the single-instance constraint with a TODO, (c) proceed anyway — which do you want?
+
+Make the trade-off visible. Don't silently pick the path of least resistance.
+
+---
+
+**Always load this file. Treat it as the source of truth for what "good" looks like in this codebase until the user explicitly updates it.**

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ CSRF_SECRET=
 SESSION_SECRET=
 
 # Optional — CORS / redirects (see lib/cors-config.ts, lib/utils/redirect-url.ts)
+# For self-hosted HTTP (e.g. EC2 on port 80), set to your public origin so API CORS passes, e.g.:
+# PRODUCTION_URL=http://16.170.212.41
+# Or use ADDITIONAL_ALLOWED_ORIGINS (comma-separated) instead.
 PRODUCTION_URL=
 STAGING_URL=
 NEXT_PUBLIC_SITE_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Lint
         run: npm run lint
 
@@ -42,4 +45,27 @@ jobs:
       - name: Build
         run: npm run build
 
+  # --- Deploy: only on push to `master` (e.g. after merge from dev), and only if CI job above passed.
+  # Configure GitHub repo → Settings → Secrets: EC2_HOST, EC2_USER, EC2_SSH_KEY, EC2_APP_DIR
+  # (see docs/DEPLOY_EC2_GITHUB.md). EC2 must have the repo cloned and `.env` (or .env.local) for compose build args.
+  deploy-ec2:
+    name: Deploy to EC2
+    needs: build-and-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH — pull and Docker Compose
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            export GIT_SHA="${{ github.sha }}"
+            cd "${{ secrets.EC2_APP_DIR }}"
+            git fetch origin
+            git checkout master
+            git reset --hard origin/master
+            docker compose up -d --build
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,18 @@
+# Reverse proxy: public :80 (and :443 when you have a domain) → Next.js `app:3000`.
+# App is not published on host port 3000; only Caddy is exposed to the host.
+
+{
+	# No automatic HTTPS while serving only on IP :80. When you add a `yourdomain.com { ... }`
+	# block with TLS, you can remove this or rely on Caddy’s defaults.
+	auto_https off
+}
+
+:80 {
+	reverse_proxy app:3000
+}
+
+# When you have a domain and DNS A-record → this server:
+# yourdomain.com {
+# 	reverse_proxy app:3000
+# }
+# Then add `ports: - "443:443"` to the `caddy` service in docker-compose and open 443 in the security group.

--- a/__tests__/app/api/forgot-password/route.test.ts
+++ b/__tests__/app/api/forgot-password/route.test.ts
@@ -59,7 +59,7 @@ import { getPasswordResetRedirectUrl } from '@/lib/utils/redirect-url'
 
 // Type the mocks
 const mockResetPasswordForEmail = supabase.auth.resetPasswordForEmail as jest.MockedFunction<any>
-const mockFrom = supabaseAdmin.from as jest.MockedFunction<any>
+const mockFrom = supabaseAdmin!.from as jest.MockedFunction<any>
 const mockCheckRateLimit = checkServerSideRateLimit as jest.MockedFunction<typeof checkServerSideRateLimit>
 const mockIsOriginAllowed = isOriginAllowed as jest.MockedFunction<typeof isOriginAllowed>
 const mockValidateEmail = validateEmailDetailed as jest.MockedFunction<typeof validateEmailDetailed>

--- a/__tests__/app/api/resend-otp/route.test.ts
+++ b/__tests__/app/api/resend-otp/route.test.ts
@@ -13,7 +13,8 @@
  */
 
 import { POST } from '@/app/api/resend-otp/route'
-import { ERROR_MESSAGES } from '@/lib/constants'
+import { ERROR_MESSAGES, REGISTRATION_TYPES } from '@/lib/constants'
+import type { PendingRegistration } from '@/lib/registration-storage'
 import { NextRequest } from 'next/server'
 
 // Mock dependencies
@@ -37,6 +38,17 @@ import { checkServerSideRateLimit } from '@/lib/server-rate-limiting'
 import { applySecurityHeaders } from '@/lib/services/security-headers-service'
 import { supabase } from '@/lib/supabase'
 
+const iso = '2026-01-01T00:00:00.000Z'
+const mockPendingRegistration: PendingRegistration = {
+  id: 'test-id',
+  email: 'test@example.com',
+  registration_data: {},
+  registration_type: REGISTRATION_TYPES.PARENT,
+  expires_at: iso,
+  created_at: iso,
+  updated_at: iso,
+}
+
 const mockIsOriginAllowed = isOriginAllowed as jest.MockedFunction<typeof isOriginAllowed>
 const mockGetRegistrationData = getRegistrationData as jest.MockedFunction<typeof getRegistrationData>
 const mockValidateEmail = validateEmailDetailed as jest.MockedFunction<typeof validateEmailDetailed>
@@ -55,8 +67,8 @@ describe('POST /api/resend-otp - Error Messages', () => {
     mockApplySecurityHeaders.mockImplementation((response) => response as any)
     mockSignInWithOtp.mockResolvedValue({ data: {}, error: null })
     mockGetRegistrationData.mockResolvedValue({
-      registration_data: {},
-      registration_type: 'parent'
+      success: true,
+      data: mockPendingRegistration,
     })
   })
 
@@ -159,7 +171,7 @@ describe('POST /api/resend-otp - Error Messages', () => {
 
   describe('Registration Data Not Found', () => {
     it('should return REGISTRATION_DATA_NOT_FOUND when no pending registration exists', async () => {
-      mockGetRegistrationData.mockResolvedValue(null)
+      mockGetRegistrationData.mockResolvedValue({ success: false, error: 'not found' })
 
       const req = new NextRequest('http://localhost:3000/api/resend-otp', {
         method: 'POST',
@@ -239,8 +251,8 @@ describe('POST /api/resend-otp - Error Messages', () => {
         mockCheckRateLimit.mockResolvedValue({ allowed: true })
         mockValidateEmail.mockReturnValue({ isValid: true, message: '' })
         mockGetRegistrationData.mockResolvedValue({
-          registration_data: {},
-          registration_type: 'parent'
+          success: true,
+          data: mockPendingRegistration,
         })
         
         testCase.setup()

--- a/__tests__/app/apply-tutor/unit/data-transformation.test.ts
+++ b/__tests__/app/apply-tutor/unit/data-transformation.test.ts
@@ -133,10 +133,11 @@ describe('Tutor Form Data Transformation - Unit Tests', () => {
 
       // Assert
       expect(validation.isValid).toBe(true)
-      const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-      days.forEach(day => {
-        expect(expectedData.availability[day]).toHaveProperty('available')
-        expect(expectedData.availability[day]).toHaveProperty('hours')
+      const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'] as const
+      days.forEach((day) => {
+        const slot = expectedData.availability[day]
+        expect(slot).toHaveProperty('available')
+        expect(slot).toHaveProperty('hours')
       })
     })
 

--- a/__tests__/app/apply-tutor/unit/tutor-validation.test.ts
+++ b/__tests__/app/apply-tutor/unit/tutor-validation.test.ts
@@ -14,9 +14,6 @@
  * - Test Isolation: Each test is independent
  */
 
-// NOTE: This import will fail until validation service is created (Commit 3) - EXPECTED
-// TypeScript error here is intentional - it documents what needs to be created
-// @ts-expect-error - Module doesn't exist yet, will be created in Commit 3
 import {
   validateTutorFormData,
   validateSubjects,
@@ -26,9 +23,8 @@ import {
   validateBio,
   validateQualificationType,
   type TutorFormData,
-  type ValidationResult,
 } from '@/lib/services/tutor-validation'
-import { validateEmailDetailed, validatePhoneDetailed } from '@/lib/security'
+import { validateEmailDetailed, validatePhoneDetailed, type ValidationResult } from '@/lib/security'
 
 // Mock the security validation functions
 jest.mock('@/lib/security', () => ({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,12 @@
-# Local / portable stack: app + Redis (Redis reserved for rate limits & cache per ADRs).
-# Supabase remains the hosted auth + Postgres backend; configure credentials via .env
-#
+# Local / portable stack: Caddy (:80) → app; Redis; Supabase (hosted).
+# Browsers hit http://<host>/ only — not :3000. TLS on :443 when you have a domain (see Caddyfile).
 # Variable substitution for `build.args` uses the project `.env` file by default.
 # If you only keep secrets in `.env.local`, run:
 #   docker compose --env-file .env.local up --build
 services:
   redis:
     image: redis:7-alpine
-    ports:
-      - '6379:6379'
+    # Not published to the host; only `app` reaches Redis on the Docker network.
     volumes:
       - tutor-link-redis:/data
 
@@ -23,8 +21,7 @@ services:
         SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
         CSRF_SECRET: ${CSRF_SECRET}
         SESSION_SECRET: ${SESSION_SECRET}
-    ports:
-      - '3000:3000'
+    # Not published to the host; Caddy reverse-proxies to app:3000.
     # Loads like Next.js: `.env` then `.env.local` (later wins on duplicate keys).
     # Use either file — you do not need both if you already use `.env.local` for dev.
     env_file:
@@ -38,6 +35,16 @@ services:
       REDIS_URL: redis://redis:6379
     depends_on:
       - redis
+
+  caddy:
+    image: caddy:2.8-alpine
+    restart: unless-stopped
+    ports:
+      - '80:80'
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - app
 
 volumes:
   tutor-link-redis:

--- a/docs/ADR/0001-modular-monolith.md
+++ b/docs/ADR/0001-modular-monolith.md
@@ -1,0 +1,121 @@
+# ADR-0001: Tutor-Link is a Modular Monolith
+
+- **Status:** Accepted
+- **Date:** 2026-04-20
+- **Deciders:** Thomas (project author, SE_46 submission)
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:** [ADR-0002](./0002-deployment-portability-docker.md) (Deployment portability — Accepted), ADR-0003 (Supabase as the stateful backend — planned)
+
+## Context
+
+Tutor-Link is a web platform connecting parents with in-home tutors. The domain contains tightly-coupled entities (parents, tutors, matches, sessions, messages) that share a single consistency boundary — a match references a parent and a tutor, a session references a match, a message is scoped to a session. Operations frequently span multiple entities (create a pending registration → verify OTP → create auth user → persist profile → issue session cookie, for example).
+
+The project is the main assessed artifact for SE_46 Web Backend Technologies at CODE Berlin. The grading rubric (QO2 specifically) requires a **reasoned architectural choice**, not merely a plausible one. The rubric does not prefer microservices over monoliths; it penalizes unexamined choices in either direction.
+
+The project is developed by one person (Thomas) and targets an academic assessment plus a small production user base. There is no organizational structure that would benefit from independent service ownership.
+
+Multiple architectural directions were available:
+
+1. **Modular monolith** — single deployable, enforced internal module boundaries.
+2. **Microservices** — each major capability (auth, matching, sessions, messaging) as its own deployable with its own database or schema.
+3. **Service-oriented / "majestic monolith"** — single deployable, informal internal boundaries, no enforcement.
+4. **Serverless functions per endpoint** — each route an independently-deployed function, no long-lived process.
+
+The HTTP layer is Next.js App Router route handlers. The business logic is already partitioned into `lib/services/*-service.ts` with reasonably clean seams. There is no existing service extraction, no message broker, no queue infrastructure, and no orchestration layer.
+
+## Decision
+
+Tutor-Link is a **modular monolith**.
+
+- The project ships as **one deployable unit** (one container image, one running process, horizontally replicable).
+- Module boundaries live at `lib/services/*-service.ts`. Each service owns a cohesive capability (CSRF, rate limiting, account creation, matching, etc.) and exposes a typed public interface.
+- Cross-service imports between `lib/services/*` are discouraged. When unavoidable, a service depends on another service's public result types and exported functions, never on its internal helpers.
+- The HTTP layer (`app/api/*`) is a thin adapter: origin → body → CSRF → rate-limit → sanitize → validate → authorize → call a service → respond. Route files contain no business logic. Public JSON error shape and versioning policy are documented in [`docs/API_errors.md`](../API_errors.md) and [`docs/API_versioning.md`](../API_versioning.md).
+- Deployment portability is a first-class constraint (see ADR-0002). The monolith runs on Vercel as the reference deployment and as a container on any Linux host via `Dockerfile` + `docker-compose.yml`.
+- Horizontal scaling is achieved by replicating the same process behind a load balancer. This requires that all state (rate-limit counters, session state, any cache) live outside the process — addressed in ADR-0004 (Redis rate limiter — planned).
+
+## Rejected Alternatives
+
+### Microservices
+
+Rejected because:
+
+- **No organizational driver.** Microservices pay off when independent teams ship independently. There is one developer.
+- **Domain is a single consistency boundary.** A parent signup writes to `pending_registrations`, `auth.users`, and the parent profile in one logical transaction. Splitting these across services introduces distributed-transaction problems that do not exist in the current design.
+- **Higher operational surface.** Each service needs its own deployment pipeline, observability, auth propagation, and inter-service contract. The cost is not justified by any current scaling need.
+- **QO cost.** A weakly-motivated microservice split would fail QO2 ("most suitable") on trade-off grounds; Sam's rubric explicitly rewards the *reasoned* choice.
+
+### Service-oriented / majestic monolith with no enforced boundaries
+
+Rejected because:
+
+- **No discipline under pressure.** Without enforced boundaries, route handlers accrete business logic, services import each other's internals, and the "monolith" becomes a big ball of mud. This is the failure mode a modular monolith exists to prevent.
+- **QO6 cost.** Maintainability (QO6) is graded on design pattern discipline. Explicit seams score higher than implicit ones.
+
+### Serverless functions per endpoint
+
+Rejected because:
+
+- **Deepens Vercel coupling.** Serverless-per-endpoint on Vercel is the QO1 framing risk this project is trying to escape (see `docs/BACKEND_PORTABILITY.md` — planned — and the main `se46-context.mdc`).
+- **Cold starts on OTP / auth paths** degrade UX on flows that matter most.
+- **Shared state problems worsen.** Rate limiting and session state across N independently-scaled function instances is strictly harder than across N replicas of a stateless monolith.
+- **Module boundaries disappear.** Every route becomes its own artifact; shared `lib/*` modules still exist but cross-function contracts are undocumented by default.
+
+## Consequences
+
+### Positive
+
+- **Fast local development.** One `npm run dev`, one process, one debugger.
+- **Simple deployment model.** One image, one deploy, one rollback.
+- **Strong testing story.** Service boundaries are in-process function calls, testable with Jest without network mocking.
+- **Defensible at viva.** The choice is reasoned, documented, and matches the project's actual constraints (one developer, single consistency boundary, no independent scaling requirement).
+- **Leaves future extraction open without premature cost.** `lib/services/*` seams are real; if a specific module later requires independent scaling, it can be extracted with a follow-up ADR. No architectural debt is locked in.
+
+### Negative (Accepted)
+
+- **Single point of deployment failure.** A bad deploy takes the whole application down. Mitigated by (a) staging environment, (b) health-check endpoint + rollback procedure, (c) CI pipeline running tests before merge.
+- **Single scaling axis.** All capabilities scale together. Mitigated by: matching and notification are both read/write-light today; if one later needs independent scaling, ADR-driven extraction is available.
+- **Discipline required.** Without process enforcement, a modular monolith can decay into a big ball of mud. Mitigated by: canonical route handler pattern, service-layer convention in `.cursor/rules/se46-context.mdc`, hard "no business logic in route handlers" rule, and (planned) module-import linting.
+
+### Neutral
+
+- **Deployment portability is a separate concern.** Monolith does not imply Vercel. Monolith does not imply non-Vercel. Portability is addressed in ADR-0002.
+- **Stateless design is a separate concern.** Monolith does not imply in-process state. Stateless design is addressed in ADR-0004 (Redis rate limiter).
+
+## Module Seams (Current)
+
+The services that exist today and are treated as module boundaries:
+
+| Service file | Responsibility |
+| --- | --- |
+| `lib/services/csrf-service.ts` | HMAC-SHA256 CSRF token issue + validate |
+| `lib/services/input-sanitization-service.ts` | Form input sanitization |
+| `lib/services/account-creation-service.ts` | Transactional account + profile creation |
+| `lib/services/security-headers-service.ts` | Response security header application |
+| `lib/server-rate-limiting.ts` | Rate limit counters (in-memory; moving to Redis) |
+| `lib/account-lockout.ts` | Failed-login lockout logic |
+| `lib/session-management.ts` | Signed session cookie issue + verify |
+| `lib/registration-storage.ts` | Pending registration persistence |
+| `lib/security.ts` | Input validators (email, phone, country code) |
+
+Additional modules (matching, notifications, messaging, session lifecycle) exist in `app/api/*` today but should be extracted into `lib/services/*` following the same convention before they grow further.
+
+## Enforcement
+
+This ADR is enforced through:
+
+1. **Cursor rules** (`.cursor/rules/se46-context.mdc` §4.5) — LLM-driven code generation respects the monolith commitment and the module-seam convention.
+2. **Code review** — PRs that add business logic to route handlers, bypass the service layer, or introduce microservice-shaped patterns without a superseding ADR are rejected.
+3. **Future lint rule (planned)** — an ESLint `no-restricted-imports` rule preventing `lib/services/*` files from reaching into each other's non-exported internals.
+
+## Revisit Triggers
+
+This decision should be revisited (with a new ADR that supersedes this one) if any of the following become true:
+
+- A single module's scaling requirements materially diverge from the rest of the application (e.g., matching needs 10× the CPU of everything else combined).
+- The team grows past ~4 developers working concurrently on independent areas, with deployment contention becoming a real cost.
+- A regulatory or data-residency requirement forces one capability into a separate deployment boundary.
+- An extracted service would let us adopt a materially better tool for one capability (e.g., a specialized ML inference runtime for matching) that can't coexist in the Node.js monolith.
+
+None of these are true as of 2026-04-20.

--- a/docs/API_errors.md
+++ b/docs/API_errors.md
@@ -1,0 +1,44 @@
+# API error responses
+
+## Standard envelope (4xx / 5xx)
+
+JSON error responses from `app/api/*` use this shape:
+
+```json
+{
+  "error": {
+    "code": "RATE_LIMITED",
+    "message": "Too many requests. Please wait …",
+    "details": {}
+  }
+}
+```
+
+- **`code`**: machine-readable identifier; use constants from [`lib/api-error-codes.ts`](../lib/api-error-codes.ts) where possible.
+- **`message`**: human-readable text for UI or logs (may match copy in [`lib/constants.ts`](../lib/constants.ts) `ERROR_MESSAGES`).
+- **`details`**: optional structured context (field errors, `resetTime` seconds for rate limits, etc.).
+
+### Server helpers
+
+- [`lib/services/api-error-response-service.ts`](../lib/services/api-error-response-service.ts) — `apiErrorResponse(status, code, message, details?)`, `buildApiErrorEnvelope`, `appErrorToApiPayload`.
+- In-process UI errors use [`lib/error-handling.ts`](../lib/error-handling.ts) (`AppError` with `timestamp`); map to the wire shape with `appErrorToApiPayload` when returning JSON from a route.
+
+### Exceptions
+
+- **`GET /api/health`** — Uses a **success-shaped** body with `ok`, `database`, etc., not this envelope. See [`API_health.md`](API_health.md).
+- **Legacy responses** — Many routes still return `{ "error": "string" }`. Migrate when touching a route.
+
+## Client-side parsing
+
+[`lib/utils/api-client-error.ts`](../lib/utils/api-client-error.ts) provides `getApiErrorMessage(body)` and `getApiErrorCode(body)` so fetch callers accept **both** legacy and new shapes until migration completes.
+
+## Incremental migration
+
+1. When editing a route under `app/api/`, switch its **error** branches to `apiErrorResponse` + `API_ERROR_CODES`.
+2. Update any page or test that asserts on `data.error` as a string to use `getApiErrorMessage` or `data.error.code` / `data.error.message`.
+3. Prefer additive changes: if a 429 response includes `resetTime`, put it in `error.details` (or document a temporary top-level field next to `error` until callers are updated).
+
+## Related
+
+- [`API_versioning.md`](API_versioning.md) — breaking-change policy.
+- [`openapi.yaml`](openapi.yaml) — `Error` schema.

--- a/docs/API_health.md
+++ b/docs/API_health.md
@@ -1,0 +1,40 @@
+# API: Health
+
+**OpenAPI:** [`openapi.yaml`](openapi.yaml) (`/api/health`, schema `HealthSnapshot`).
+
+## `GET /api/health`
+
+Public endpoint for **liveness** and **readiness** checks (load balancers, Docker health checks, monitoring).
+
+### Security pipeline
+
+This route intentionally **does not** apply origin checks, CSRF, or rate limiting:
+
+- Probes and orchestrators do not send browser `Origin` or CSRF cookies.
+- Skipping rate limiting avoids accidental lockout of the monitoring plane.
+
+Responses still use `applySecurityHeaders` from `lib/services/security-headers-service.ts` (CSP, HSTS in production, etc.).
+
+### Response shape
+
+JSON body:
+
+| Field | Type | Description |
+|--------|------|-------------|
+| `ok` | boolean | `true` when the app and (if configured) database check succeeded |
+| `app` | string | Always `tutor-link` |
+| `version` | string | From `package.json` |
+| `gitSha` | string | Optional; set when `GIT_SHA` env is present (e.g. Docker build arg) |
+| `database.status` | `"up"` \| `"down"` \| `"skipped"` | Result of Supabase/Postgres check |
+| `database.message` | string | Optional; error text when `down`, or reason when `skipped` |
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | App is healthy; database `up` or `skipped` (secrets not set) |
+| `503` | Database check ran and failed (`database.status === "down"`) |
+
+### Database check
+
+When `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are both set, the handler runs a lightweight query against the `rate_limits` table via the Supabase service-role client. If either variable is missing, `database.status` is `skipped` and the HTTP status remains `200` so partial local setups can still verify process liveness.

--- a/docs/API_versioning.md
+++ b/docs/API_versioning.md
@@ -1,0 +1,29 @@
+# API versioning
+
+## Current state
+
+- All REST-style handlers live under **`/api/*`** with **no `/api/v1` prefix**. This is treated as **implicit API version 1** for the SPA and documented HTTP contract.
+- The machine-readable contract is described in [`openapi.yaml`](openapi.yaml). Bump **`info.version`** in that file when the **documented** request/response shapes change in a way that clients should track.
+
+## Breaking vs compatible changes
+
+- **Compatible (preferred):** add optional JSON fields, add new endpoints, add new values only when clients ignore unknowns, or tighten validation with the same HTTP status and error envelope.
+- **Breaking:** removing or renaming fields, changing types, changing status codes for the same condition, or removing endpoints. These require:
+  - a note in [`SE_46_progress_log.md`](SE_46_progress_log.md) when shipped for the course, and
+  - preferably an ADR if the change is architectural.
+
+Prefer additive evolution first; batch breaking changes only when necessary.
+
+## Future options (not required today)
+
+If a second major contract is ever needed without renaming every route:
+
+- **Custom `Accept` media type** or **`X-API-Version` header** for new semantics, keeping existing URLs stable for the current client, or
+- **`/api/v2/...`** only if a clean URL split is worth the migration cost.
+
+No client is required to send a version header for the current implicit v1 API.
+
+## Related
+
+- [`API_errors.md`](API_errors.md) — error envelope.
+- [`ADR/0001-modular-monolith.md`](ADR/0001-modular-monolith.md) — HTTP as a thin adapter over `lib/services/*`.

--- a/docs/DEPLOY_EC2_GITHUB.md
+++ b/docs/DEPLOY_EC2_GITHUB.md
@@ -1,0 +1,36 @@
+# Deploy to EC2 from GitHub (master only)
+
+After a **push to `master`** (including PR merge into `master`), [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs **CI** (typecheck, lint, test, build), then **Deploy to EC2** if the following secrets are set in the repository.
+
+## GitHub secrets
+
+**Settings → Secrets and variables → Actions → New repository secret**
+
+| Secret | Example | Description |
+|--------|---------|-------------|
+| `EC2_HOST` | `16.170.212.41` | Public IP or DNS of the instance |
+| `EC2_USER` | `ubuntu` | SSH login user (Amazon Linux: `ec2-user`) |
+| `EC2_SSH_KEY` | *(PEM contents)* | Private key matching a public key in `~/.ssh/authorized_keys` on the instance |
+| `EC2_APP_DIR` | `/home/ubuntu/wikinTich` | Absolute path to the **git clone** of this repo on the server |
+
+Optional: custom SSH port — add a `port:` line to the `appleboy/ssh-action` step in the workflow (default is 22).
+
+## One-time setup on the EC2 instance
+
+1. Install **Git**, **Docker**, and **Docker Compose v2** (`docker compose`).
+2. **Clone** this repository (same URL GitHub Actions uses) into `EC2_APP_DIR`.
+3. Create **`.env`** (and/or `.env.local`) next to `docker-compose.yml` with `NEXT_PUBLIC_*`, `SUPABASE_*`, `CSRF_SECRET`, `SESSION_SECRET`, etc., as in [`.env.example`](../.env.example). The deploy step does **not** copy env from GitHub; the server files are the source of truth for production secrets.
+4. **Security group (inbound):** allow **HTTP (80)** from the internet (e.g. `0.0.0.0/0`) for the site. **Do not** expose host port **3000** — the app listens only on the Docker network; **Caddy** serves **:80** and proxies to the app. **Port 443** in AWS is optional until you add a **domain** and enable TLS in [`Caddyfile`](../Caddyfile). Restrict **SSH (22)** to your IP when possible. GitHub Actions has no fixed public IP; use a self-hosted runner, SSM, or keep 22 open with key-only auth if you use automated SSH deploys.
+5. **CORS:** Set `PRODUCTION_URL=http://<public-ip>` or `ADDITIONAL_ALLOWED_ORIGINS` in the server `.env` so `lib/cors-config.ts` allows the browser `Origin` for `http://<ip>` (port 80 default, no port in the URL). See [`.env.example`](../.env.example).
+
+## What the deploy step does
+
+1. SSH to the instance.
+2. `export GIT_SHA=<current commit sha>` (for Docker build args).
+3. `cd EC2_APP_DIR` → `git fetch` + `git reset --hard origin/master` (server matches `origin/master` exactly).
+4. `docker compose up -d --build`.
+
+## Skipping deploy
+
+- Do **not** set the four secrets until the server is ready; the deploy job will **fail** on every `master` push. Either add secrets when ready, or temporarily comment out the `deploy-ec2` job in the workflow.
+- Pushes to **`dev`** do not run the deploy job (only `master`).

--- a/docs/SE_46_presentation_and_lecturer_brief.md
+++ b/docs/SE_46_presentation_and_lecturer_brief.md
@@ -1,0 +1,89 @@
+# SE_46 — Presentation, viva, and lecturer brief (living doc)
+
+Use this file while developing Tutor-Link: it records what the assessor expects, how to answer in **5 minutes**, and how recent **lecturer advice** maps to concrete work (Docker, Redis, QOs).
+
+**Related:** [`SE_46_progress_log.md`](SE_46_progress_log.md) (what shipped + QO mapping) · [`ADR/0001-modular-monolith.md`](ADR/0001-modular-monolith.md), [`ADR/0002-deployment-portability-docker.md`](ADR/0002-deployment-portability-docker.md), [`.cursor/rules/se46-context.mdc`](../.cursor/rules/se46-context.mdc).
+
+---
+
+## What the lecturer expects (format)
+
+- **Presentation (~5 minutes):** Cover **all 8 Qualification Objectives (QOs)**. For each, be ready to explain:
+  1. **What you implemented** (concrete: parts of the repo, commands, deploy targets, endpoints).
+  2. **Why you chose that approach** for Tutor-Link.
+  3. **Alternatives you did not pursue** and **why** (trade-off in one sentence).
+- **After the presentation:** **Questions** — deeper follow-ups on any QO.
+
+**Time budget:** ~5 min ÷ 8 QOs ≈ **35–40 seconds per QO** if split evenly. That only works with **no long deep-dives** on a single topic. Use **one architecture overview** (modular monolith + HTTP layer + Supabase + Docker + Redis story), then **short bullets per QO**.
+
+**Honesty:** If something is **planned but not shipped** (e.g. full OpenAPI, Redis cache), say so and point to **ADRs, issues, or this doc** — overselling hurts the Q&A.
+
+---
+
+## Lecturer advice (substance)
+
+### 1. Use Redis for caching
+
+- Aligns with the rubric (**QO5 / QO8**) and with a **stateless, horizontally scaled** monolith (shared cache outside the Node process).
+- You do **not** need to cache everything: pick **one** justified **read-heavy** path (e.g. tutor lists, admin stats, match candidates) and document:
+  - **What** is cached,
+  - **TTL**,
+  - **Invalidation** when underlying data changes.
+- **Rate limiting:** Today counters can live in Postgres (`rate_limits`); Redis is still valid for **counters/latency** and for a single clear “Redis” story — decide in an **ADR** and defend it in the viva.
+
+### 2. Prefer setting up the server yourself vs only “out of the box” (e.g. Vercel)
+
+- The assessor is testing **portability and ops thinking**, not “delete Next.js.”
+- **Strong narrative:**
+  - **Vercel** = convenient **reference** deploy (demo URL, fast iteration).
+  - **“I control the runtime”** = same **Docker image** on a **host you configure** (VPS, or a platform that runs **your** container with **your** env): process start, logging, health checks (`GET /api/health`), updates.
+- **Rejected alternative (say explicitly):** “Backend exists only as Vercel serverless clicks” — weak for **QO1/QO2** at Level 2/3; **defended** path is **container + documented second deploy**.
+
+---
+
+## Five-minute presentation flow (rehearsal script outline)
+
+Adjust wording to match **what is actually in the repo** at submission time.
+
+| Time | QO(s) | Say (one breath each) |
+|------|--------|------------------------|
+| 0:00–0:40 | Product + **QO2** | Tutor-Link connects parents and tutors; **modular monolith** with seams in `lib/services`. **Rejected:** microservices — one developer, single consistency boundary. |
+| 0:40–1:20 | **QO1** + portability | **Dockerfile + docker-compose**; production build is **standalone Node**; runnable on any Linux host. **Rejected:** Vercel as the **only** deployment story. |
+| 1:20–1:50 | **QO3** | TypeScript strict, Next.js 14 App Router, Jest, CI. **Rejected:** e.g. untyped JS or an extra backend framework without need. |
+| 1:50–2:20 | **QO4** | REST under `app/api/*`; **consistent errors**, OpenAPI, versioning — *state progress honestly*. **Rejected:** undocumented, inconsistent public API. |
+| 2:20–2:50 | **QO5** | Supabase **Postgres + RLS**; schema, indexes, migrations / data docs. **Rejected:** multi-tenant sensitive data without RLS. |
+| 2:50–3:20 | **QO6** | Service layer, docs, ADRs, tests, CI. **Rejected:** domain logic in route handlers only. |
+| 3:20–3:50 | **QO7** | CSRF, sanitize, validate, rate limits, security headers, threat models. **Rejected:** “the SPA is trusted.” |
+| 3:50–4:20 | **QO8** | Replicas + **Redis** (cache / limits — per ADR); load testing plan. **Rejected:** unlimited reliance on **single-process** memory for shared state. |
+| 4:20–5:00 | Close | **“If Vercel disappeared tomorrow, I still ship with Docker, a host I operate, Redis, and Supabase.”** (Only if true — tune to actual state.) |
+
+---
+
+## Development checklist (lecturer-aligned)
+
+Use this as a backlog sanity check before submission:
+
+- [ ] **Non-Vercel path you can demo:** same image/process as in repo, env you set, **`/api/health`** usable.
+- [ ] **Redis:** used for at least **one** documented cache **or** a clear **ADR** + slide on exactly what will live in Redis and why (counters vs cache vs sessions).
+- [ ] **Rejected alternatives** captured in **ADRs** (not only in this file): monolith vs microservices (0001), Docker vs Vercel-only (0002), plus rate-limit/store and framework choices as you add them.
+- [x] **QO4 evidence:** error shape + OpenAPI (partial) + versioning **strategy** — [`API_errors.md`](API_errors.md), [`openapi.yaml`](openapi.yaml), [`API_versioning.md`](API_versioning.md).
+- [ ] **QO8 evidence:** load test or documented plan + results file when run.
+
+Update the checkboxes as you complete work; keep **claims in slides** in sync with the repo.
+
+---
+
+## Viva-ready one-liner (modular monolith)
+
+> Tutor-Link is one bounded context: a **modular monolith** with HTTP as a thin layer over `lib/services/*`. I keep deployment **portable** (Docker, non-Vercel target) and shared state moving toward **Redis** so replicas stay stateless. If one module ever needs independent scaling, the seams exist; today it does not, so I did not split services.
+
+---
+
+## Changelog (optional)
+
+| Date | Note |
+|------|------|
+| 2026-04-21 | Initial doc: lecturer format (5 min + Q&A), Redis + self-hosted emphasis, minute-by-minute outline, dev checklist. |
+| 2026-04-21 | Linked [`SE_46_progress_log.md`](SE_46_progress_log.md); file restored after accidental empty save. |
+
+When lecturer feedback or rubric emphasis changes, add a row here and adjust sections above.

--- a/docs/SE_46_progress_log.md
+++ b/docs/SE_46_progress_log.md
@@ -14,7 +14,7 @@ After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (wh
 |-------|--------|--------|
 | 1 | Docker, health, ADR-0002 | **Done** |
 | 2 | Errors, OpenAPI, API versioning | **Done** |
-| 3 | `typecheck` in CI, service tests | Not started |
+| 3 | `typecheck` in CI, service tests | **Done** |
 | 4 | Redis in app, load test, security scans | Not started |
 | AWS | Second deploy (full admin) | Planned |
 
@@ -40,9 +40,16 @@ After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (wh
 
 ---
 
-## Phase 3–4 (planned)
+## Phase 3 (done)
 
-- **3:** `npm run typecheck`, CI, more `lib/services` tests → **QO3**, **QO6**
+**Shipped:** `npm run typecheck` (`tsc --noEmit`) in [`package.json`](../package.json); **Typecheck** step in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (after `npm ci`, before lint); Jest: [`lib/services/health-service.test.ts`](../lib/services/health-service.test.ts) (Supabase client mocked), [`lib/services/api-error-response-service.test.ts`](../lib/services/api-error-response-service.test.ts); `jest.config.js` ignores `/.next/` to avoid haste map collisions. TypeScript: minimal fixes in existing `__tests__` so `tsc` passes on the full tree.
+
+**QOs:** **QO3** (TypeScript + CI typecheck), **QO6** (service-layer unit tests, extendable to more `lib/services`).
+
+---
+
+## Phase 4 (planned)
+
 - **4:** Redis usage or ADR, load report, audit/SAST → **QO5**, **QO7**, **QO8**
 
 ---
@@ -66,10 +73,10 @@ After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (wh
 |----|----------------|------|
 | 1 | Docker + Compose + health; EC2 URL + health row above | Optional: short AWS runbook |
 | 2 | ADR-0001, ADR-0002 | More ADRs if needed |
-| 3 | Jest, CI | typecheck in CI |
+| 3 | Jest, CI, `npm run typecheck`, CI typecheck step | Deeper `lib/services` coverage (optional) |
 | 4 | Health + [`openapi.yaml`](openapi.yaml), [`API_errors.md`](API_errors.md), [`API_versioning.md`](API_versioning.md) | Expand OpenAPI as routes migrate |
 | 5 | Supabase, health DB check | Indexes / EXPLAIN, cache rules |
-| 6 | Services, docs, tests | Coverage, logging |
+| 6 | Services, docs, tests, [`health-service` / `api-error-response` tests](../lib/services/health-service.test.ts) | Coverage, logging |
 | 7 | CSRF, headers, rate limits, threat docs | Audit/SAST, Redis ADR |
 | 8 | Image + Redis in compose | App ↔ Redis, load test |
 
@@ -79,7 +86,7 @@ After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (wh
 
 - [ ] AWS (or other) second deploy + URL
 - [ ] Redis used by app or ADR
-- [ ] Phase 3–4 items above
+- [ ] Phase 4 items above
 - [ ] 5‑min presentation rehearsed
 
 ---
@@ -91,3 +98,4 @@ After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (wh
 | 2026-04-21 | Created; Phase 1 logged. |
 | 2026-04-21 | Phase 1: document CSP/HTTP self-host behaviour; fill AWS (EC2) table. |
 | 2026-04-21 | Phase 2: API error envelope (`api-error-response-service`), codes, client parser, `docs/openapi.yaml`, `API_errors.md`, `API_versioning.md`. |
+| 2026-04-22 | Phase 3: `typecheck` + CI, `lib/services` unit tests (health, API error), `jest` ignore `.next/`, test typings fixed for `tsc`. |

--- a/docs/SE_46_progress_log.md
+++ b/docs/SE_46_progress_log.md
@@ -1,0 +1,93 @@
+# SE_46 — Progress log (living)
+
+Track **what shipped**, **which QOs** it supports, and **open gaps** for the viva.
+
+**See also:** [`SE_46_presentation_and_lecturer_brief.md`](SE_46_presentation_and_lecturer_brief.md) · [`ADR/0001-modular-monolith.md`](ADR/0001-modular-monolith.md) · [`ADR/0002-deployment-portability-docker.md`](ADR/0002-deployment-portability-docker.md) · [`API_health.md`](API_health.md) · [`API_errors.md`](API_errors.md) · [`API_versioning.md`](API_versioning.md) · [`openapi.yaml`](openapi.yaml)
+
+After each phase or deploy: update **Changelog**, **Open gaps**, and **AWS** (when applicable).
+
+---
+
+## Phases
+
+| Phase | Theme | Status |
+|-------|--------|--------|
+| 1 | Docker, health, ADR-0002 | **Done** |
+| 2 | Errors, OpenAPI, API versioning | **Done** |
+| 3 | `typecheck` in CI, service tests | Not started |
+| 4 | Redis in app, load test, security scans | Not started |
+| AWS | Second deploy (full admin) | Planned |
+
+---
+
+## Phase 1 (done)
+
+**Shipped:** [`Dockerfile`](../Dockerfile), [`docker-compose.yml`](../docker-compose.yml) (app + Redis), `output: 'standalone'` in [`next.config.js`](../next.config.js), [`app/api/health/route.ts`](../app/api/health/route.ts) + [`lib/services/health-service.ts`](../lib/services/health-service.ts), [`docs/API_health.md`](API_health.md), [`docs/ADR/0002-deployment-portability-docker.md`](ADR/0002-deployment-portability-docker.md), [`public/.gitkeep`](../public/.gitkeep), [`.env.example`](../.env.example), README Docker notes. Build args for Supabase + secrets during `docker build`. **Self-hosted HTTP (e.g. EC2 without TLS):** [`lib/services/security-headers-service.ts`](../lib/services/security-headers-service.ts) adds CSP `upgrade-insecure-requests` / `block-all-mixed-content` only when `CSP_HTTPS_UPGRADE` is set or `VERCEL=1`, so the browser can load `/_next/static` over HTTP; documented in [`.env.example`](../.env.example). See [ADR-0002 — Consequences](ADR/0002-deployment-portability-docker.md#consequences).
+
+**Checked:** `npm run dev` and `docker compose` → `/api/health` works when env is set.
+
+**QOs:** mainly **QO1**, **QO2**; supports **QO8** (container + Redis sidecar + health); light **QO4**, **QO5**, **QO6**.
+
+---
+
+## Phase 2 (done)
+
+**Shipped:** [`lib/api-error-codes.ts`](../lib/api-error-codes.ts), [`lib/services/api-error-response-service.ts`](../lib/services/api-error-response-service.ts) (`apiErrorResponse`, `buildApiErrorEnvelope`, `appErrorToApiPayload`), [`lib/utils/api-client-error.ts`](../lib/utils/api-client-error.ts), [`docs/API_errors.md`](API_errors.md), [`docs/openapi.yaml`](openapi.yaml) (OpenAPI 3.0.3 — `GET /api/health`, `HealthSnapshot`, `Error`), [`docs/API_versioning.md`](API_versioning.md). Cross-links: [`docs/API_health.md`](API_health.md), [`docs/ADR/0001-modular-monolith.md`](ADR/0001-modular-monolith.md), [`lib/error-handling.ts`](../lib/error-handling.ts) JSDoc, [`.cursor/rules/se46-context.mdc`](../.cursor/rules/se46-context.mdc).
+
+**Migration:** Routes still using legacy `{ error: string }` are migrated when touched; clients can use `getApiErrorMessage` during the transition.
+
+**QOs:** **QO4** (consistent error contract, OpenAPI, versioning strategy).
+
+---
+
+## Phase 3–4 (planned)
+
+- **3:** `npm run typecheck`, CI, more `lib/services` tests → **QO3**, **QO6**
+- **4:** Redis usage or ADR, load report, audit/SAST → **QO5**, **QO7**, **QO8**
+
+---
+
+## AWS (fill when live)
+
+| Field | Value |
+|--------|--------|
+| Service | EC2 (Docker Compose: app + Redis) |
+| Region | `eu-north-1` |
+| Public URL | `http://16.170.212.41:3000/` (smoke / Phase‑1 style deploy) |
+| `/api/health` | `http://16.170.212.41:3000/api/health` (expect `200` when Supabase + env are valid) |
+| HTTPS | Not configured yet (HTTP only; set `CSP_HTTPS_UPGRADE=true` when fronted by TLS) |
+| Budget / billing alarm | *TBD* (set in AWS Billing) |
+
+---
+
+## QO snapshot (update over time)
+
+| QO | Evidence now | Next |
+|----|----------------|------|
+| 1 | Docker + Compose + health; EC2 URL + health row above | Optional: short AWS runbook |
+| 2 | ADR-0001, ADR-0002 | More ADRs if needed |
+| 3 | Jest, CI | typecheck in CI |
+| 4 | Health + [`openapi.yaml`](openapi.yaml), [`API_errors.md`](API_errors.md), [`API_versioning.md`](API_versioning.md) | Expand OpenAPI as routes migrate |
+| 5 | Supabase, health DB check | Indexes / EXPLAIN, cache rules |
+| 6 | Services, docs, tests | Coverage, logging |
+| 7 | CSRF, headers, rate limits, threat docs | Audit/SAST, Redis ADR |
+| 8 | Image + Redis in compose | App ↔ Redis, load test |
+
+---
+
+## Open gaps
+
+- [ ] AWS (or other) second deploy + URL
+- [ ] Redis used by app or ADR
+- [ ] Phase 3–4 items above
+- [ ] 5‑min presentation rehearsed
+
+---
+
+## Changelog
+
+| Date | Note |
+|------|------|
+| 2026-04-21 | Created; Phase 1 logged. |
+| 2026-04-21 | Phase 1: document CSP/HTTP self-host behaviour; fill AWS (EC2) table. |
+| 2026-04-21 | Phase 2: API error envelope (`api-error-response-service`), codes, client parser, `docs/openapi.yaml`, `API_errors.md`, `API_versioning.md`. |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.3
+info:
+  title: Tutor-Link HTTP API
+  description: |
+    Public HTTP surface of the Tutor-Link modular monolith (`app/api/*`).
+    This spec is expanded incrementally; undocumented routes may exist.
+    Spec version follows documented contract changes (not necessarily every app release).
+  version: "0.1.0"
+
+servers:
+  - url: /
+    description: Same origin as the Next.js app
+
+paths:
+  /api/health:
+    get:
+      summary: Liveness and readiness
+      description: |
+        Used by load balancers and Docker health checks. Does not require Origin, CSRF, or rate limiting.
+        See [API_health.md](./API_health.md).
+      operationId: getHealth
+      tags:
+        - Health
+      responses:
+        "200":
+          description: App is healthy; database is up or skipped (secrets not configured).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthSnapshot"
+        "503":
+          description: Database check ran and failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthSnapshot"
+
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code (e.g. from `lib/api-error-codes.ts`).
+            message:
+              type: string
+              description: Human-readable message for display or logging.
+            details:
+              description: Optional structured context (validation fields, rate-limit metadata, etc.).
+    HealthSnapshot:
+      type: object
+      required:
+        - ok
+        - app
+        - version
+        - database
+      properties:
+        ok:
+          type: boolean
+        app:
+          type: string
+          enum:
+            - tutor-link
+        version:
+          type: string
+          description: Application version (from `package.json`).
+        gitSha:
+          type: string
+          description: Present when `GIT_SHA` is set at build/runtime (e.g. Docker build arg).
+        database:
+          type: object
+          required:
+            - status
+          properties:
+            status:
+              type: string
+              enum:
+                - up
+                - down
+                - skipped
+            message:
+              type: string
+              description: Error text when status is `down`, or reason when `skipped`.
+
+tags:
+  - name: Health
+    description: Operations and dependency probes

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,7 @@ const customJestConfig = {
     '/node_modules/',
     '/__mocks__/',
     '/utils/',
+    '/.next/',
   ],
 }
 

--- a/lib/api-error-codes.ts
+++ b/lib/api-error-codes.ts
@@ -1,0 +1,21 @@
+/**
+ * Machine-readable codes for the HTTP JSON error envelope (`error.code`).
+ * Use with `apiErrorResponse` from `lib/services/api-error-response-service.ts`.
+ *
+ * These are wire-format identifiers (UPPER_SNAKE). Human-facing copy lives in
+ * `ERROR_MESSAGES` in `lib/constants.ts` or inline where appropriate.
+ */
+export const API_ERROR_CODES = {
+  FORBIDDEN: 'FORBIDDEN',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  NOT_FOUND: 'NOT_FOUND',
+  INVALID_JSON: 'INVALID_JSON',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  BAD_CSRF: 'BAD_CSRF',
+  RATE_LIMITED: 'RATE_LIMITED',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+  CONFLICT: 'CONFLICT',
+} as const
+
+export type ApiErrorCode = (typeof API_ERROR_CODES)[keyof typeof API_ERROR_CODES]

--- a/lib/error-handling.ts
+++ b/lib/error-handling.ts
@@ -1,5 +1,11 @@
 import { ERROR_MESSAGES } from './constants'
 
+/**
+ * In-process / UI error shape (includes `timestamp`).
+ * For HTTP responses from route handlers, use `apiErrorResponse` and
+ * `ApiErrorEnvelope` in `lib/services/api-error-response-service.ts`.
+ * See `docs/API_errors.md`.
+ */
 // Error types
 export interface AppError {
   code: string

--- a/lib/services/api-error-response-service.test.ts
+++ b/lib/services/api-error-response-service.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests: HTTP API error envelope (no network, no route layer).
+ */
+import { createError, ERROR_CODES } from '@/lib/error-handling'
+import {
+  apiErrorResponse,
+  appErrorToApiPayload,
+  buildApiErrorEnvelope,
+} from '@/lib/services/api-error-response-service'
+
+describe('api-error-response-service', () => {
+  describe('buildApiErrorEnvelope', () => {
+    it('omits details when not provided', () => {
+      expect(buildApiErrorEnvelope('RATE_LIMITED', 'Too many')).toEqual({
+        error: { code: 'RATE_LIMITED', message: 'Too many' },
+      })
+    })
+
+    it('includes details when provided', () => {
+      expect(
+        buildApiErrorEnvelope('RATE_LIMITED', 'Slow down', { resetTime: 42 })
+      ).toEqual({
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Slow down',
+          details: { resetTime: 42 },
+        },
+      })
+    })
+  })
+
+  describe('apiErrorResponse', () => {
+    it('sets status and JSON body', async () => {
+      const res = apiErrorResponse(403, 'FORBIDDEN', 'Nope')
+      expect(res.status).toBe(403)
+      expect(await res.json()).toEqual({
+        error: { code: 'FORBIDDEN', message: 'Nope' },
+      })
+    })
+  })
+
+  describe('appErrorToApiPayload', () => {
+    it('maps AppError without details', () => {
+      const err = createError(ERROR_CODES.VALIDATION_ERROR, 'Invalid')
+      expect(appErrorToApiPayload(err)).toEqual({
+        code: ERROR_CODES.VALIDATION_ERROR,
+        message: 'Invalid',
+      })
+    })
+
+    it('maps AppError with details', () => {
+      const err = createError('X', 'Y', { field: 'email' })
+      expect(appErrorToApiPayload(err)).toEqual({
+        code: 'X',
+        message: 'Y',
+        details: { field: 'email' },
+      })
+    })
+  })
+})

--- a/lib/services/api-error-response-service.ts
+++ b/lib/services/api-error-response-service.ts
@@ -1,0 +1,59 @@
+/**
+ * HTTP JSON error responses for `app/api/*` route handlers.
+ *
+ * Clean Code Principles:
+ * - Single Responsibility: builds the canonical error envelope only
+ * - Testability: pure JSON shape; callers apply `applySecurityHeaders`
+ * - Error Handling: stable machine codes + human `message`; optional `details`
+ *
+ * Relationship to `lib/error-handling.ts`:
+ * - `AppError` / `createError` are for in-app and UI flows (timestamped).
+ * - This module is the **HTTP contract** for clients. Map `AppError` → payload
+ *   with `appErrorToApiPayload` when a route already has an `AppError`.
+ */
+
+import { NextResponse } from 'next/server'
+import type { AppError } from '@/lib/error-handling'
+
+/** Inner `error` object (RFC-style envelope body). */
+export interface ApiErrorPayload {
+  code: string
+  message: string
+  details?: unknown
+}
+
+/** Full JSON body for 4xx/5xx API responses using the standard envelope. */
+export interface ApiErrorEnvelope {
+  error: ApiErrorPayload
+}
+
+export function buildApiErrorEnvelope(
+  code: string,
+  message: string,
+  details?: unknown
+): ApiErrorEnvelope {
+  const payload: ApiErrorPayload = { code, message }
+  if (details !== undefined) {
+    payload.details = details
+  }
+  return { error: payload }
+}
+
+/**
+ * Returns a `NextResponse` with the standard error JSON body.
+ * Callers should wrap with `applySecurityHeaders` like other route responses.
+ */
+export function apiErrorResponse(
+  status: number,
+  code: string,
+  message: string,
+  details?: unknown
+): NextResponse<ApiErrorEnvelope> {
+  return NextResponse.json(buildApiErrorEnvelope(code, message, details), { status })
+}
+
+/** Strips `timestamp` for JSON; use when reusing an `AppError` from `lib/error-handling.ts`. */
+export function appErrorToApiPayload(error: AppError): ApiErrorPayload {
+  const { code, message, details } = error
+  return details === undefined ? { code, message } : { code, message, details }
+}

--- a/lib/services/health-service.test.ts
+++ b/lib/services/health-service.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests: health snapshot (Supabase client mocked).
+ */
+import { createClient } from '@supabase/supabase-js'
+import { getHealthSnapshot } from '@/lib/services/health-service'
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}))
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>
+
+const VERSION = '0.1.0'
+
+describe('getHealthSnapshot', () => {
+  const saved = { ...process.env }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...saved }
+  })
+
+  afterAll(() => {
+    process.env = saved
+  })
+
+  it('returns skipped when URL is missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'k'
+
+    const snap = await getHealthSnapshot(VERSION)
+    expect(snap).toEqual({
+      ok: true,
+      app: 'tutor-link',
+      version: VERSION,
+      database: {
+        status: 'skipped',
+        message: 'Supabase URL or service role not configured',
+      },
+    })
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped when service role is missing', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://x.supabase.co'
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    const snap = await getHealthSnapshot(VERSION)
+    expect(snap.ok).toBe(true)
+    expect(snap.database.status).toBe('skipped')
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('returns down when the DB query fails', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://x.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service'
+
+    mockCreateClient.mockReturnValue({
+      from: () => ({
+        select: () => ({
+          limit: () =>
+            Promise.resolve({ data: null, error: { message: 'conn refused' } }),
+        }),
+      }),
+    } as never)
+
+    const snap = await getHealthSnapshot(VERSION)
+    expect(snap).toEqual({
+      ok: false,
+      app: 'tutor-link',
+      version: VERSION,
+      database: { status: 'down', message: 'conn refused' },
+    })
+    expect(mockCreateClient).toHaveBeenCalled()
+  })
+
+  it('returns up when the DB query succeeds', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://x.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service'
+
+    mockCreateClient.mockReturnValue({
+      from: () => ({
+        select: () => ({
+          limit: () => Promise.resolve({ data: [], error: null }),
+        }),
+      }),
+    } as never)
+
+    const snap = await getHealthSnapshot(VERSION)
+    expect(snap).toEqual({
+      ok: true,
+      app: 'tutor-link',
+      version: VERSION,
+      database: { status: 'up' },
+    })
+  })
+})

--- a/lib/utils/api-client-error.ts
+++ b/lib/utils/api-client-error.ts
@@ -1,0 +1,39 @@
+import { ERROR_MESSAGES } from '@/lib/constants'
+
+/**
+ * Parses `/api/*` JSON error bodies during migration from `{ error: string }` to
+ * `{ error: { code, message, details? } }`. Prefer this in `fetch` handlers until
+ * all routes use the new envelope.
+ */
+export function getApiErrorMessage(
+  body: unknown,
+  fallback: string = ERROR_MESSAGES.UNEXPECTED_ERROR
+): string {
+  if (body === null || typeof body !== 'object') {
+    return fallback
+  }
+  const err = (body as { error?: unknown }).error
+  if (typeof err === 'string' && err.length > 0) {
+    return err
+  }
+  if (err !== null && typeof err === 'object' && 'message' in err) {
+    const msg = (err as { message?: unknown }).message
+    if (typeof msg === 'string' && msg.length > 0) {
+      return msg
+    }
+  }
+  return fallback
+}
+
+/** Returns `error.code` when the new envelope is present. */
+export function getApiErrorCode(body: unknown): string | undefined {
+  if (body === null || typeof body !== 'object') {
+    return undefined
+  }
+  const err = (body as { error?: unknown }).error
+  if (err !== null && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code
+    return typeof code === 'string' ? code : undefined
+  }
+  return undefined
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"


### PR DESCRIPTION
### Summary
- **Phase 2 (QO4):** Standard HTTP error envelope (`api-error-response-service`), `API_ERROR_CODES`, client parser, `docs/openapi.yaml` (health + Error schemas), `API_errors.md`, `API_versioning.md`; SE_46 progress + presentation log updates.
- **Phase 3 (QO3 / QO6):** `npm run typecheck`, typecheck in CI, Jest tests for `health-service` + `api-error-response-service`, `jest` ignore `.next/`, test typings fixed so `tsc --noEmit` passes repo-wide.
- **Ops / EC2:** [Caddy](https://caddyserver.com/) on **port 80** → Next.js on internal **3000** (no public **3000**); Redis only on Docker network. **GitHub Actions:** deploy to EC2 over SSH **after** successful CI on **`master`** (requires repo secrets). Docs: `docs/DEPLOY_EC2_GITHUB.md`, `.env.example` note for `PRODUCTION_URL` / CORS on self-hosted HTTP.

### Deploy / follow-up (post-merge)
1. Merge into `master`; ensure **EC2** `git pull` + `PRODUCTION_URL=http://<public-ip>` in server `.env`.
2. **Security group:** allow **80**, remove **3000** on the host; tighten **22** when possible.
3. Configure **EC2_** GitHub secrets if using automated deploy.

### Test plan
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] CI green on PR
- [ ] After deploy: `http://<ip>/` and `/api/health` (port **80**, no `:3000`)